### PR TITLE
fix: popper z index

### DIFF
--- a/.changeset/forty-dragons-double.md
+++ b/.changeset/forty-dragons-double.md
@@ -1,0 +1,5 @@
+---
+"@shoplflow/base": patch
+---
+
+모달 내부에 popper 위치시 modal 뒤에 content가 나타나는 문제 수정

--- a/packages/base/src/components/Dropdown/Dropdown.mdx
+++ b/packages/base/src/components/Dropdown/Dropdown.mdx
@@ -41,14 +41,8 @@ Dropdown은 총 세가지 컴포넌트로 나뉘어집니다.
 
 ```
 <Dropdown
-  isOpen={true}
-  trigger={
-    <InputButton
-      placeholder={'Dropdown 안에 InputButton을 넣었어요.'}
-      rightSource={<IconButton iconSource={RightArrowIcon} styleVar={'GHOST'} sizeVar={'S'} />}
-    />
-  }
-  content={<Dropdown.Content type={'FILL'}>Content</Dropdown.Content>}
+  content={<Dropdown.Content>dropdown content</Dropdown.Content>}
+  trigger={<Dropdown.Button placeholder={'테스트 버튼'} />}
 />
 ```
 

--- a/packages/base/src/components/Dropdown/Dropdown.styled.ts
+++ b/packages/base/src/components/Dropdown/Dropdown.styled.ts
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { boxShadowTokens } from '../../styles';
+import { boxShadowTokens, colorTokens } from '../../styles';
 import type { DropdownButtonProps, DropdownContentProps, DropdownSizeVariantType } from './Dropdown.types';
 import { motion } from 'framer-motion';
 import { css } from '@emotion/react';
@@ -78,6 +78,7 @@ export const StyledDropdown = styled.div`
 export const StyledDropdownContent = styled.div<DropdownContentProps>`
   display: flex;
   flex-direction: column;
+  background: ${colorTokens.neutral0};
   width: ${({ width }) => width ?? '240px'};
   padding: 4px;
   border-radius: 6px;

--- a/packages/base/src/components/Modal/Modal.stories.tsx
+++ b/packages/base/src/components/Modal/Modal.stories.tsx
@@ -9,6 +9,7 @@ import { Text } from '../Text';
 import { Stack } from '../Stack';
 import { Button } from '../Buttons';
 import { useHandleModal } from '../../hooks';
+import { Dropdown } from '../Dropdown';
 
 export default {
   title: 'COMPONENTS/Modal',
@@ -27,6 +28,10 @@ const PrimaryComponent: StoryFn<ModalContainerProps> = (args) => {
         <Text typography={'title1_700'}>모달 헤더 영역</Text>
       </Modal.Header>
       <Modal.Body>
+        <Dropdown
+          content={<Dropdown.Content>dropdown content</Dropdown.Content>}
+          trigger={<Dropdown.Button placeholder={'테스트 버튼'} />}
+        />
         <Stack.Vertical>{mockBoxs.map((box) => box)}</Stack.Vertical>
       </Modal.Body>
       <Modal.Footer>
@@ -40,7 +45,11 @@ const PrimaryComponent: StoryFn<ModalContainerProps> = (args) => {
 
 export const Playground: StoryFn<ModalContainerProps> = (args) => {
   const { addModal } = useHandleModal();
-  return <Button onClick={() => addModal(<PrimaryComponent {...args} />)}>open Modal</Button>;
+  return (
+    <>
+      <Button onClick={() => addModal(<PrimaryComponent {...args} />)}>open Modal</Button>
+    </>
+  );
 };
 
 export const Primary = () => {

--- a/packages/base/src/components/Popper/Popper.tsx
+++ b/packages/base/src/components/Popper/Popper.tsx
@@ -64,7 +64,7 @@ export const PopperPortal = forwardRef<HTMLDivElement, PopperPortalProps>(
     const refs = useMergeRefs(ref, setFloating);
 
     return (
-      <FloatingPortal>
+      <FloatingPortal id={'popper-portal-key'}>
         <AnimatePresence>
           {isOpen && (
             <motion.div

--- a/packages/base/src/portal/PopperPortal.tsx
+++ b/packages/base/src/portal/PopperPortal.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { createPortal } from 'react-dom';
+
+const PopperPortal = () => {
+  return (
+    <>
+      {createPortal(
+        <div
+          id={'popper-portal-key'}
+          style={{
+            zIndex: 20001,
+          }}
+        />,
+        document.body,
+      )}
+    </>
+  );
+};
+
+export default PopperPortal;

--- a/packages/base/src/providers/ShoplflowProvider.tsx
+++ b/packages/base/src/providers/ShoplflowProvider.tsx
@@ -4,6 +4,7 @@ import { useDomain } from '../hooks/useDomain';
 import type { DomainType } from '../types/Domain';
 import ModalPortal from '../portal/ModalPortal';
 import ModalProvider from './ModalProvider';
+import PopperPortal from '../portal/PopperPortal';
 
 export interface ShoplflowProviderProps {
   domain?: DomainType;
@@ -15,7 +16,9 @@ const ShoplflowProvider = ({ children, domain = 'SHOPL' }: ShoplflowProviderProp
 
   return (
     <ModalProvider>
+      <PopperPortal />
       <ModalPortal />
+
       {children}
     </ModalProvider>
   );


### PR DESCRIPTION
## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->
- modal 내부에서 popper 사용시 modal 뒤에 contents가 생성되는 문제 수정

<!-- 관련있는 이슈 번호(#000)를 PR 제목에 적어주세요. -->

<!-- ex) [SF-1234] 무슨 기능 업데이트 -->

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
