### PR TITLE
fix: modal open 시, 스크롤 방지 로직 추가, inputButton 스타일 변경

### DIFF
--- a/.changeset/few-cups-draw.md
+++ b/.changeset/few-cups-draw.md
@@ -1,0 +1,5 @@
+---
+"@shoplflow/base": patch
+---
+
+update: InputButton 삭제 버튼 컬러 변경, ModalProvider 바디 스크롤 방지 로직 추가

--- a/packages/base/src/components/Inputs/InputButton/InputButton.tsx
+++ b/packages/base/src/components/Inputs/InputButton/InputButton.tsx
@@ -76,7 +76,7 @@ const InputButton = forwardRef<HTMLInputElement, InputButtonProps>(
           <Stack.Horizontal align={'center'}>
             {text && (
               <IconButton sizeVar={'S'} onClick={handleOnClear} styleVar={'GHOST'} disabled={disabled}>
-                <Icon iconSource={assetFunction('DeleteIcon')} color={'neutral600'} />
+                <Icon iconSource={assetFunction('DeleteIcon')} color={'neutral350'} />
               </IconButton>
             )}
             {rightSource}

--- a/packages/base/src/providers/ModalProvider.tsx
+++ b/packages/base/src/providers/ModalProvider.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { RemoveModalProps } from '../hooks/ModalContext';
 import { ModalContext, ModalHandlerContext } from '../hooks/ModalContext';
 import { isNullOrUndefined } from '@shoplflow/utils';
@@ -63,6 +63,15 @@ const ModalProvider = ({ children }: ModalProviderProps) => {
     }
   };
   const dispatch = useMemo(() => ({ addModal, removeModal }), []);
+
+  useEffect(() => {
+    if (openedModals.length === 1) {
+      document.body.style.cssText = 'overflow:hidden';
+      return () => {
+        document.body.style.cssText = 'overflow:unset';
+      };
+    }
+  }, [openedModals.length]);
 
   return (
     <ModalContext.Provider value={openedModals}>


### PR DESCRIPTION
- InputButton > DeleteIcon color > neutral350
- ModalProvider > body 스크롤 방지 로직 추가

## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->


<!-- 관련있는 이슈 번호(#000)를 PR 제목에 적어주세요. -->

<!-- ex) [SF-1234] 무슨 기능 업데이트 -->

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
