### PR TITLE
feat: menu

### DIFF
--- a/.changeset/silver-chefs-crash.md
+++ b/.changeset/silver-chefs-crash.md
@@ -1,0 +1,5 @@
+---
+"@shoplflow/base": patch
+---
+
+feat: Menu leftSource checkbox, radio 컴포넌트일 경우에만 isSelected 미처리

--- a/packages/base/src/components/ControlButtons/Checkbox/Checkbox.tsx
+++ b/packages/base/src/components/ControlButtons/Checkbox/Checkbox.tsx
@@ -4,6 +4,8 @@ import { Container, StyledCheckbox } from './Checkbox.styled';
 import type { CheckboxProps } from './Checkbox.types';
 import { useOnToggle } from '../../../hooks/useOnToggle';
 
+export const CheckboxSymbol = Symbol('shoplflow-checkbox');
+
 const Checkbox = ({
   defaultSelected,
   isSelected,
@@ -56,5 +58,7 @@ const Checkbox = ({
     </Container>
   );
 };
+
+Checkbox[CheckboxSymbol] = true;
 
 export default Checkbox;

--- a/packages/base/src/components/ControlButtons/Checkbox/Checkbox.tsx
+++ b/packages/base/src/components/ControlButtons/Checkbox/Checkbox.tsx
@@ -4,7 +4,7 @@ import { Container, StyledCheckbox } from './Checkbox.styled';
 import type { CheckboxProps } from './Checkbox.types';
 import { useOnToggle } from '../../../hooks/useOnToggle';
 
-export const CheckboxSymbol = Symbol('shoplflow-checkbox');
+export const CHECKBOX_SYMBOL_KEY = Symbol('SHOPLFLOW_CHECKBOX');
 
 const Checkbox = ({
   defaultSelected,
@@ -59,6 +59,6 @@ const Checkbox = ({
   );
 };
 
-Checkbox[CheckboxSymbol] = true;
+Checkbox[CHECKBOX_SYMBOL_KEY] = true;
 
 export default Checkbox;

--- a/packages/base/src/components/ControlButtons/MinusButton/MinusButton.tsx
+++ b/packages/base/src/components/ControlButtons/MinusButton/MinusButton.tsx
@@ -2,6 +2,8 @@ import React, { forwardRef } from 'react';
 import * as StyledMinusBox from './MinusButton.styled';
 import type { MinusBoxProps } from './MinusButton.types';
 
+export const MUNUS_BUTTON_SYMBOL_KEY = Symbol('SHOPLFLOW_MUNUS_BUTTON');
+
 const MinusButton = forwardRef<HTMLButtonElement, MinusBoxProps>(({ onClick, color = 'neutral300', ...rest }, ref) => {
   return (
     <StyledMinusBox.Container data-shoplflow={'minusButton'}>
@@ -22,5 +24,7 @@ const MinusButton = forwardRef<HTMLButtonElement, MinusBoxProps>(({ onClick, col
     </StyledMinusBox.Container>
   );
 });
+
+MinusButton[MUNUS_BUTTON_SYMBOL_KEY] = true;
 
 export default MinusButton;

--- a/packages/base/src/components/ControlButtons/Radio/Radio.tsx
+++ b/packages/base/src/components/ControlButtons/Radio/Radio.tsx
@@ -4,6 +4,8 @@ import { Container, StyledRadio } from './Radio.styled';
 import type { RadioProps } from './Radio.types';
 import { useOnToggle } from '../../../hooks/useOnToggle';
 
+export const RadioSymbol = Symbol('shoplflow-radio');
+
 const Radio = ({ isSelected, defaultSelected, disabled, onClick, onMouseEnter, onMouseLeave, ...rest }: RadioProps) => {
   const [selected, toggleSelected] = useOnToggle(isSelected, defaultSelected);
   const [isHovered, toggleHovered] = useState(false);
@@ -39,5 +41,7 @@ const Radio = ({ isSelected, defaultSelected, disabled, onClick, onMouseEnter, o
     </Container>
   );
 };
+
+Radio[RadioSymbol] = true;
 
 export default Radio;

--- a/packages/base/src/components/ControlButtons/Radio/Radio.tsx
+++ b/packages/base/src/components/ControlButtons/Radio/Radio.tsx
@@ -4,7 +4,7 @@ import { Container, StyledRadio } from './Radio.styled';
 import type { RadioProps } from './Radio.types';
 import { useOnToggle } from '../../../hooks/useOnToggle';
 
-export const RadioSymbol = Symbol('shoplflow-radio');
+export const RADIO_SYMBOL_KEY = Symbol('SHOPLFLOW_RADIO');
 
 const Radio = ({ isSelected, defaultSelected, disabled, onClick, onMouseEnter, onMouseLeave, ...rest }: RadioProps) => {
   const [selected, toggleSelected] = useOnToggle(isSelected, defaultSelected);
@@ -42,6 +42,6 @@ const Radio = ({ isSelected, defaultSelected, disabled, onClick, onMouseEnter, o
   );
 };
 
-Radio[RadioSymbol] = true;
+Radio[RADIO_SYMBOL_KEY] = true;
 
 export default Radio;

--- a/packages/base/src/components/Menu/Menu.styled.ts
+++ b/packages/base/src/components/Menu/Menu.styled.ts
@@ -3,7 +3,8 @@ import { colorTokens } from '../../styles';
 import type { MenuOptionProps } from './Menu.types';
 import { getDisabledStyle } from '../../styles/utils/getDisabledStyle';
 import { css } from '@emotion/react';
-import { CheckboxSymbol, RadioSymbol } from '../ControlButtons';
+import { CHECKBOX_SYMBOL_KEY, RADIO_SYMBOL_KEY } from '../ControlButtons';
+import { MUNUS_BUTTON_SYMBOL_KEY } from '../ControlButtons/MinusButton/MinusButton';
 
 const getStylesBySizeVar = (sizeVar: MenuOptionProps['sizeVar']) => {
   switch (sizeVar) {
@@ -56,7 +57,11 @@ export const StyledMenu = styled.li<MenuOptionProps>`
   ${({ disabled }) => disabled && getDisabledStyle(disabled)}
   ${({ isSelected, leftSource }) =>
     isSelected === true &&
-    (!leftSource || (leftSource && !leftSource.type[RadioSymbol] && !leftSource.type[CheckboxSymbol])) &&
+    (!leftSource ||
+      (leftSource &&
+        !leftSource.type[RADIO_SYMBOL_KEY] &&
+        !leftSource.type[CHECKBOX_SYMBOL_KEY] &&
+        !leftSource.type[MUNUS_BUTTON_SYMBOL_KEY])) &&
     css`
       background: ${colorTokens.neutral200};
       &:hover {

--- a/packages/base/src/components/Menu/Menu.styled.ts
+++ b/packages/base/src/components/Menu/Menu.styled.ts
@@ -3,6 +3,7 @@ import { colorTokens } from '../../styles';
 import type { MenuOptionProps } from './Menu.types';
 import { getDisabledStyle } from '../../styles/utils/getDisabledStyle';
 import { css } from '@emotion/react';
+import { CheckboxSymbol, RadioSymbol } from '../ControlButtons';
 
 const getStylesBySizeVar = (sizeVar: MenuOptionProps['sizeVar']) => {
   switch (sizeVar) {
@@ -55,7 +56,7 @@ export const StyledMenu = styled.li<MenuOptionProps>`
   ${({ disabled }) => disabled && getDisabledStyle(disabled)}
   ${({ isSelected, leftSource }) =>
     isSelected === true &&
-    !leftSource &&
+    (!leftSource || (leftSource && !leftSource.type[RadioSymbol] && !leftSource.type[CheckboxSymbol])) &&
     css`
       background: ${colorTokens.neutral200};
       &:hover {


### PR DESCRIPTION
## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->
feature: Menu 컴포넌트
- leftSource가 있는 경우 isSelected 효과 X -> leftSource가 Checkbox, Radio, MinusButton  경우에만 적용되도록 변경하였습니다.

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
