### PR TITLE
fix: ModalProvider 모달 노출 시, 배경 스크롤 방지 로직 수정

### DIFF
--- a/.changeset/hip-buttons-try.md
+++ b/.changeset/hip-buttons-try.md
@@ -1,0 +1,5 @@
+---
+"@shoplflow/base": patch
+---
+
+fix: ModalProvider 배경 스크롤 방지 로직 수정

--- a/packages/base/src/components/Dropdown/DropdownButton.tsx
+++ b/packages/base/src/components/Dropdown/DropdownButton.tsx
@@ -64,7 +64,7 @@ export const DropdownButton = forwardRef<HTMLButtonElement, DropdownButtonProps>
               duration: 0.2,
             }}
           >
-            <Icon iconSource={DownArrowSolidXsmallIcon} color={'neutral400'} sizeVar='S' />
+            <Icon iconSource={DownArrowSolidXsmallIcon} color={'neutral400'} sizeVar='XS' />
           </DropdownButtonIcon>
         </StyledDropdownButton>
       </InputWrapper>

--- a/packages/base/src/components/Modal/providers/ModalProvider.tsx
+++ b/packages/base/src/components/Modal/providers/ModalProvider.tsx
@@ -66,12 +66,14 @@ const ModalProvider = ({ children }: ModalProviderProps) => {
   const dispatch = useMemo(() => ({ addModal, removeModal }), []);
 
   useEffect(() => {
-    if (openedModals.length === 1) {
-      document.body.style.cssText = 'overflow:hidden';
-      return () => {
-        document.body.style.cssText = 'overflow:unset';
-      };
+    if (openedModals.length !== 1) {
+      return;
     }
+
+    document.body.style.cssText = 'overflow:hidden';
+    return () => {
+      document.body.style.cssText = 'overflow:unset';
+    };
   }, [openedModals.length]);
 
   return (


### PR DESCRIPTION
## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->
- ModalProvider 내부의 모달 노출 시,  2개 이상의 모달 노출 시, 스크롤 되던 이슈를 수정 했습니다.

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
