### PR TITLE
fix: InputButton value가 비어있어도 상태 업데이트에 반영되도록 수정

### DIFF
--- a/.changeset/wise-nails-decide.md
+++ b/.changeset/wise-nails-decide.md
@@ -1,0 +1,5 @@
+---
+"@shoplflow/base": patch
+---
+
+inputButton 빈 string에도 변경될 수 있게 수정

--- a/packages/base/src/components/Inputs/InputButton/InputButton.tsx
+++ b/packages/base/src/components/Inputs/InputButton/InputButton.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent } from 'react';
-import React, { forwardRef, useCallback, useEffect, useState } from 'react';
+import React, { useRef, forwardRef, useCallback, useEffect, useState } from 'react';
 import { StyledInputButton, StyledInputButtonContent } from './InputButton.styled';
 import { InputWrapper } from '../common/input.styled';
 import { Stack } from '../../Stack';
@@ -15,7 +15,7 @@ const InputButton = forwardRef<HTMLInputElement, InputButtonProps>(
   ) => {
     const [text, setText] = useState('');
     const [isHovered, setIsHovered] = useState(false);
-
+    const prevValue = useRef(value);
     const convertToString = useCallback((value: string | number | readonly string[]) => {
       if (typeof value !== 'number') {
         return typeof value === 'string' ? value : value.join('');
@@ -52,9 +52,13 @@ const InputButton = forwardRef<HTMLInputElement, InputButtonProps>(
     }, [convertToString, defaultValue]);
 
     useEffect(() => {
-      if (value) {
+      if (!(value === undefined || value === null)) {
+        if (prevValue.current === value) {
+          return;
+        }
         const convertString = convertToString(value);
         setText(convertString);
+        prevValue.current = convertString;
       }
     }, [convertToString, value]);
 


### PR DESCRIPTION
## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->
- InputButton value가 비어있어도 상태 업데이트에 반영되도록 수정

<!-- 관련있는 이슈 번호(#000)를 PR 제목에 적어주세요. -->

<!-- ex) [SF-1234] 무슨 기능 업데이트 -->

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
