### PR TITLE
update: Modal > ModalBody

### DIFF
--- a/.changeset/late-eggs-lay.md
+++ b/.changeset/late-eggs-lay.md
@@ -1,0 +1,5 @@
+---
+"@shoplflow/base": patch
+---
+
+feat: ModalBody > setContentHeightMax 함수 생성하여 BodyContainer와 ScrollArea의 maxHeight 구하는 로직을 분리하였습니다.

--- a/packages/base/src/components/Modal/ModalBody.tsx
+++ b/packages/base/src/components/Modal/ModalBody.tsx
@@ -63,7 +63,24 @@ const ModalBody = ({
 
       return windowHeight > 1200 ? heightOverMaxHeight : heightUnderMaxHeight;
     }
-    return '100%';
+    return 0;
+  };
+
+  const setContentHeightMax = () => {
+    let autoHeightMax = setAutoHeightMax();
+
+    // Content top padding 빼주기
+    autoHeightMax = autoHeightMax - 24;
+
+    if (isIncludeHeader) {
+      autoHeightMax = autoHeightMax - 24;
+    }
+
+    if (!isIncludeHeader) {
+      autoHeightMax = autoHeightMax - 16;
+    }
+
+    return autoHeightMax;
   };
 
   return (
@@ -73,7 +90,7 @@ const ModalBody = ({
         universal
         autoHeight={!modalContainerHeight}
         autoHeightMin={setAutoHeightMin()}
-        autoHeightMax={setAutoHeightMax()}
+        autoHeightMax={setContentHeightMax()}
         style={{
           height: '100%',
           overflow: 'hidden',


### PR DESCRIPTION
## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->

- ScrollArea의 컨텐츠 영역이 래핑하고 있는 영역의 패딩에 가려지는 이슈
-  ModalBody > setContentHeightMax 함수를 생성,  BodyContainer와 ScrollArea maxHeight 구하는 로직을 분리하였습니다.



## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
