### PR TITLE
fix: Stack(Container)ComponentType 수정

### DIFF
--- a/.changeset/lemon-cameras-count.md
+++ b/.changeset/lemon-cameras-count.md
@@ -1,0 +1,5 @@
+---
+"@shoplflow/base": patch
+---
+
+fix: Stack(Container)ComponentType 수정

--- a/packages/base/src/components/Stack/Stack.tsx
+++ b/packages/base/src/components/Stack/Stack.tsx
@@ -14,7 +14,7 @@ import type { StringElementType } from '../../utils/type/ComponentProps';
  * @return {StackComponentType}
  */
 const createStackComponent = (stackOption?: StackProps): StackComponentType =>
-  forwardRef(function Stack(
+  forwardRef(function Stack<T extends StringElementType = 'div'>(
     {
       as = 'div',
       spacing = stackOption?.spacing,
@@ -28,7 +28,7 @@ const createStackComponent = (stackOption?: StackProps): StackComponentType =>
       radius = stackOption?.radius,
       background = stackOption?.background,
       ...rest
-    }: StackGenericProps,
+    }: StackGenericProps<T>,
     ref: ComponentPropsWithRef<StringElementType>['ref'],
   ) {
     return (

--- a/packages/base/src/components/Stack/Stack.types.ts
+++ b/packages/base/src/components/Stack/Stack.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithRef, CSSProperties, ReactElement } from 'react';
+import type { CSSProperties, ForwardRefExoticComponent, PropsWithoutRef, RefAttributes } from 'react';
 
 import type { CustomDomComponent } from 'framer-motion';
 import type { BorderRadiusTokens, ColorTokens, SpacingTokens } from '../../styles';
@@ -13,9 +13,9 @@ export type StackGenericProps<T extends StringElementType = 'div'> = RenderConfi
   StackProps &
   HTMLPropsWithoutRef<T>;
 
-export type StackComponentType = <T extends StringElementType = 'div'>(
-  props: StackGenericProps<T> & Pick<ComponentPropsWithRef<T>, 'ref'>,
-) => ReactElement | null;
+export type StackComponentType = ForwardRefExoticComponent<
+  PropsWithoutRef<StackGenericProps> & RefAttributes<HTMLElement>
+>;
 
 export type MotionStackComponentType<T extends StringElementType = 'div'> = CustomDomComponent<
   RenderConfigProps & HTMLPropsWithoutRef<T> & StackProps

--- a/packages/base/src/components/StackContainer/StackContainer.tsx
+++ b/packages/base/src/components/StackContainer/StackContainer.tsx
@@ -19,7 +19,7 @@ import type { StringElementType } from '../../utils/type/ComponentProps';
  * @return {StackContainerComponentType}
  */
 const createStackComponent = (stackOption?: StackContainerProps): StackContainerComponentType =>
-  forwardRef(function Stack(
+  forwardRef(function Stack<T extends StringElementType = 'div'>(
     {
       as = 'div',
       spacing = stackOption?.spacing,
@@ -35,7 +35,7 @@ const createStackComponent = (stackOption?: StackContainerProps): StackContainer
       padding = stackOption?.padding ?? 'initial',
       background = stackOption?.background,
       ...rest
-    }: StackContainerGenericProps,
+    }: StackContainerGenericProps<T>,
     ref: ComponentPropsWithRef<StringElementType>['ref'],
   ) {
     return (

--- a/packages/base/src/components/StackContainer/StackContainer.types.ts
+++ b/packages/base/src/components/StackContainer/StackContainer.types.ts
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithRef, CSSProperties, ReactElement } from 'react';
+import type { CSSProperties, ForwardRefExoticComponent, PropsWithoutRef, RefAttributes } from 'react';
 
 import type { CustomDomComponent } from 'framer-motion';
 import type { BorderRadiusTokens, ColorTokens, SpacingTokens } from '../../styles';
@@ -13,9 +13,14 @@ export type StackContainerGenericProps<T extends StringElementType = 'div'> = Re
   StackContainerProps &
   HTMLPropsWithoutRef<T>;
 
-export type StackContainerComponentType = <T extends StringElementType = 'div'>(
-  props: StackContainerGenericProps<T> & Pick<ComponentPropsWithRef<T>, 'ref'>,
-) => ReactElement | null;
+// NOTICE: 주석 처리된 type과 forwardRef return type이 불일치해서, 에러 나타납니다.
+// export type StackContainerComponentType = <T extends StringElementType = 'div'>(
+//   props: StackContainerGenericProps<T> & Pick<ComponentPropsWithRef<T>, 'ref'>,
+// ) => ReactElement | null;
+
+export type StackContainerComponentType = ForwardRefExoticComponent<
+  PropsWithoutRef<StackContainerGenericProps> & RefAttributes<HTMLElement>
+>;
 
 export type MotionStackContainerComponentType<T extends StringElementType = 'div'> = CustomDomComponent<
   RenderConfigProps & HTMLPropsWithoutRef<T> & StackContainerProps

--- a/packages/hada-assets/src/icons/generated/index.ts
+++ b/packages/hada-assets/src/icons/generated/index.ts
@@ -1,90 +1,90 @@
-import Subtract from "./Subtract";
-import IcAdd from "./IcAdd";
-import IcAdmin from "./IcAdmin";
-import IcAlbum from "./IcAlbum";
-import IcAlert from "./IcAlert";
-import IcBell from "./IcBell";
-import IcCalendar from "./IcCalendar";
-import IcCamera from "./IcCamera";
-import IcCancel from "./IcCancel";
-import IcCheckActive from "./IcCheckActive";
-import IcCheckDefault from "./IcCheckDefault";
-import IcCheck from "./IcCheck";
-import IcCheckbox from "./IcCheckbox";
-import IcChecklist from "./IcChecklist";
-import IcClose from "./IcClose";
-import IcCompleted from "./IcCompleted";
-import IcCopy from "./IcCopy";
-import IcCrew from "./IcCrew";
-import IcDelete from "./IcDelete";
-import IcDownArrowSolid from "./IcDownArrowSolid";
-import IcDownArrow from "./IcDownArrow";
-import IcDownload from "./IcDownload";
-import IcDrag from "./IcDrag";
-import IcDrawer from "./IcDrawer";
-import IcEdit from "./IcEdit";
-import IcEmail from "./IcEmail";
-import IcError from "./IcError";
-import IcExcel from "./IcExcel";
-import IcFilter from "./IcFilter";
-import IcFinger from "./IcFinger";
-import IcGradeBadge from "./IcGradeBadge";
-import IcHelpCenter from "./IcHelpCenter";
-import IcHelp from "./IcHelp";
-import IcHome from "./IcHome";
-import IcInfoMedium from "./IcInfoMedium";
-import IcInfo from "./IcInfo";
-import IcIssue from "./IcIssue";
-import IcIssues from "./IcIssues";
-import IcLanguage from "./IcLanguage";
-import IcLeftArrow from "./IcLeftArrow";
-import IcLink from "./IcLink";
-import IcListEdit from "./IcListEdit";
-import IcLogout from "./IcLogout";
-import IcMemo from "./IcMemo";
-import IcMenu from "./IcMenu";
-import IcMobileview from "./IcMobileview";
-import IcMore from "./IcMore";
-import IcNewBell from "./IcNewBell";
-import IcNewIssue from "./IcNewIssue";
-import IcNewReport from "./IcNewReport";
-import IcNewTab from "./IcNewTab";
-import IcNext from "./IcNext";
-import IcNoticeLine from "./IcNoticeLine";
-import IcNotice from "./IcNotice";
-import IcOverview from "./IcOverview";
-import IcPassword from "./IcPassword";
-import IcPhone from "./IcPhone";
-import IcPlace from "./IcPlace";
-import IcQrcode from "./IcQrcode";
-import IcRadio from "./IcRadio";
-import IcReadChecklist from "./IcReadChecklist";
-import IcReadIssue from "./IcReadIssue";
-import IcReadReport from "./IcReadReport";
-import IcRefresh from "./IcRefresh";
-import IcRemove from "./IcRemove";
-import IcRightArrow from "./IcRightArrow";
-import IcSearch from "./IcSearch";
-import IcSection from "./IcSection";
-import IcSettingFill from "./IcSettingFill";
-import IcSetting from "./IcSetting";
-import IcSheet from "./IcSheet";
-import IcSlider from "./IcSlider";
-import IcStatisticActive from "./IcStatisticActive";
-import IcStatisticDefault from "./IcStatisticDefault";
-import IcStatistics from "./IcStatistics";
-import IcText from "./IcText";
-import IcTime from "./IcTime";
-import IcTrash from "./IcTrash";
-import IcTutorialCompleted from "./IcTutorialCompleted";
-import IcTutorial from "./IcTutorial";
-import IcUpArrowSolid from "./IcUpArrowSolid";
-import IcUpArrow from "./IcUpArrow";
-import IcUser from "./IcUser";
-import IcViewOff from "./IcViewOff";
-import IcViewOn from "./IcViewOn";
-import IcWorker from "./IcWorker";
-import IcYesno from "./IcYesno";
+import Subtract from './Subtract';
+import IcAdd from './IcAdd';
+import IcAdmin from './IcAdmin';
+import IcAlbum from './IcAlbum';
+import IcAlert from './IcAlert';
+import IcBell from './IcBell';
+import IcCalendar from './IcCalendar';
+import IcCamera from './IcCamera';
+import IcCancel from './IcCancel';
+import IcCheckActive from './IcCheckActive';
+import IcCheckDefault from './IcCheckDefault';
+import IcCheck from './IcCheck';
+import IcCheckbox from './IcCheckbox';
+import IcChecklist from './IcChecklist';
+import IcClose from './IcClose';
+import IcCompleted from './IcCompleted';
+import IcCopy from './IcCopy';
+import IcCrew from './IcCrew';
+import IcDelete from './IcDelete';
+import IcDownArrowSolid from './IcDownArrowSolid';
+import IcDownArrow from './IcDownArrow';
+import IcDownload from './IcDownload';
+import IcDrag from './IcDrag';
+import IcDrawer from './IcDrawer';
+import IcEdit from './IcEdit';
+import IcEmail from './IcEmail';
+import IcError from './IcError';
+import IcExcel from './IcExcel';
+import IcFilter from './IcFilter';
+import IcFinger from './IcFinger';
+import IcGradeBadge from './IcGradeBadge';
+import IcHelpCenter from './IcHelpCenter';
+import IcHelp from './IcHelp';
+import IcHome from './IcHome';
+import IcInfoMedium from './IcInfoMedium';
+import IcInfo from './IcInfo';
+import IcIssue from './IcIssue';
+import IcIssues from './IcIssues';
+import IcLanguage from './IcLanguage';
+import IcLeftArrow from './IcLeftArrow';
+import IcLink from './IcLink';
+import IcListEdit from './IcListEdit';
+import IcLogout from './IcLogout';
+import IcMemo from './IcMemo';
+import IcMenu from './IcMenu';
+import IcMobileview from './IcMobileview';
+import IcMore from './IcMore';
+import IcNewBell from './IcNewBell';
+import IcNewIssue from './IcNewIssue';
+import IcNewReport from './IcNewReport';
+import IcNewTab from './IcNewTab';
+import IcNext from './IcNext';
+import IcNoticeLine from './IcNoticeLine';
+import IcNotice from './IcNotice';
+import IcOverview from './IcOverview';
+import IcPassword from './IcPassword';
+import IcPhone from './IcPhone';
+import IcPlace from './IcPlace';
+import IcQrcode from './IcQrcode';
+import IcRadio from './IcRadio';
+import IcReadChecklist from './IcReadChecklist';
+import IcReadIssue from './IcReadIssue';
+import IcReadReport from './IcReadReport';
+import IcRefresh from './IcRefresh';
+import IcRemove from './IcRemove';
+import IcRightArrow from './IcRightArrow';
+import IcSearch from './IcSearch';
+import IcSection from './IcSection';
+import IcSettingFill from './IcSettingFill';
+import IcSetting from './IcSetting';
+import IcSheet from './IcSheet';
+import IcSlider from './IcSlider';
+import IcStatisticActive from './IcStatisticActive';
+import IcStatisticDefault from './IcStatisticDefault';
+import IcStatistics from './IcStatistics';
+import IcText from './IcText';
+import IcTime from './IcTime';
+import IcTrash from './IcTrash';
+import IcTutorialCompleted from './IcTutorialCompleted';
+import IcTutorial from './IcTutorial';
+import IcUpArrowSolid from './IcUpArrowSolid';
+import IcUpArrow from './IcUpArrow';
+import IcUser from './IcUser';
+import IcViewOff from './IcViewOff';
+import IcViewOn from './IcViewOn';
+import IcWorker from './IcWorker';
+import IcYesno from './IcYesno';
 
 const icons = {
   subtract: Subtract,
@@ -96,8 +96,8 @@ const icons = {
   calendar: IcCalendar,
   camera: IcCamera,
   cancel: IcCancel,
-  "check-active": IcCheckActive,
-  "check-default": IcCheckDefault,
+  'check-active': IcCheckActive,
+  'check-default': IcCheckDefault,
   check: IcCheck,
   checkbox: IcCheckbox,
   checklist: IcChecklist,
@@ -106,8 +106,8 @@ const icons = {
   copy: IcCopy,
   crew: IcCrew,
   delete: IcDelete,
-  "down-arrow-solid": IcDownArrowSolid,
-  "down-arrow": IcDownArrow,
+  'down-arrow-solid': IcDownArrowSolid,
+  'down-arrow': IcDownArrow,
   download: IcDownload,
   drag: IcDrag,
   drawer: IcDrawer,
@@ -117,29 +117,29 @@ const icons = {
   excel: IcExcel,
   filter: IcFilter,
   finger: IcFinger,
-  "grade-badge": IcGradeBadge,
-  "help-center": IcHelpCenter,
+  'grade-badge': IcGradeBadge,
+  'help-center': IcHelpCenter,
   help: IcHelp,
   home: IcHome,
-  "info-medium": IcInfoMedium,
+  'info-medium': IcInfoMedium,
   info: IcInfo,
   issue: IcIssue,
   issues: IcIssues,
   language: IcLanguage,
-  "left-arrow": IcLeftArrow,
+  'left-arrow': IcLeftArrow,
   link: IcLink,
-  "list-edit": IcListEdit,
+  'list-edit': IcListEdit,
   logout: IcLogout,
   memo: IcMemo,
   menu: IcMenu,
   mobileview: IcMobileview,
   more: IcMore,
-  "new-bell": IcNewBell,
-  "new-issue": IcNewIssue,
-  "new-report": IcNewReport,
-  "new-tab": IcNewTab,
+  'new-bell': IcNewBell,
+  'new-issue': IcNewIssue,
+  'new-report': IcNewReport,
+  'new-tab': IcNewTab,
   next: IcNext,
-  "notice-line": IcNoticeLine,
+  'notice-line': IcNoticeLine,
   notice: IcNotice,
   overview: IcOverview,
   password: IcPassword,
@@ -147,31 +147,31 @@ const icons = {
   place: IcPlace,
   qrcode: IcQrcode,
   radio: IcRadio,
-  "read-checklist": IcReadChecklist,
-  "read-issue": IcReadIssue,
-  "read-report": IcReadReport,
+  'read-checklist': IcReadChecklist,
+  'read-issue': IcReadIssue,
+  'read-report': IcReadReport,
   refresh: IcRefresh,
   remove: IcRemove,
-  "right-arrow": IcRightArrow,
+  'right-arrow': IcRightArrow,
   search: IcSearch,
   section: IcSection,
-  "setting-fill": IcSettingFill,
+  'setting-fill': IcSettingFill,
   setting: IcSetting,
   sheet: IcSheet,
   slider: IcSlider,
-  "statistic-active": IcStatisticActive,
-  "statistic-default": IcStatisticDefault,
+  'statistic-active': IcStatisticActive,
+  'statistic-default': IcStatisticDefault,
   statistics: IcStatistics,
   text: IcText,
   time: IcTime,
   trash: IcTrash,
-  "tutorial-completed": IcTutorialCompleted,
+  'tutorial-completed': IcTutorialCompleted,
   tutorial: IcTutorial,
-  "up-arrow-solid": IcUpArrowSolid,
-  "up-arrow": IcUpArrow,
+  'up-arrow-solid': IcUpArrowSolid,
+  'up-arrow': IcUpArrow,
   user: IcUser,
-  "view-off": IcViewOff,
-  "view-on": IcViewOn,
+  'view-off': IcViewOff,
+  'view-on': IcViewOn,
   worker: IcWorker,
   yesno: IcYesno,
 };

--- a/packages/hada-assets/src/illustrations/generated/index.ts
+++ b/packages/hada-assets/src/illustrations/generated/index.ts
@@ -1,18 +1,18 @@
-import English from "./English";
-import Korean from "./Korean";
-import ImgAlert from "./ImgAlert";
-import ImgAssignees from "./ImgAssignees";
-import ImgAverage from "./ImgAverage";
-import ImgCheckedFacility from "./ImgCheckedFacility";
-import ImgChecklist from "./ImgChecklist";
-import ImgFacility from "./ImgFacility";
-import ImgPending from "./ImgPending";
-import ImgResolved from "./ImgResolved";
-import ImgScheduled from "./ImgScheduled";
-import ImgTutorial01 from "./ImgTutorial01";
-import ImgTutorial02 from "./ImgTutorial02";
-import ImgTutorial03 from "./ImgTutorial03";
-import ImgUpgrade from "./ImgUpgrade";
+import English from './English';
+import Korean from './Korean';
+import ImgAlert from './ImgAlert';
+import ImgAssignees from './ImgAssignees';
+import ImgAverage from './ImgAverage';
+import ImgCheckedFacility from './ImgCheckedFacility';
+import ImgChecklist from './ImgChecklist';
+import ImgFacility from './ImgFacility';
+import ImgPending from './ImgPending';
+import ImgResolved from './ImgResolved';
+import ImgScheduled from './ImgScheduled';
+import ImgTutorial01 from './ImgTutorial01';
+import ImgTutorial02 from './ImgTutorial02';
+import ImgTutorial03 from './ImgTutorial03';
+import ImgUpgrade from './ImgUpgrade';
 
 const illustrations = {
   english: English,
@@ -20,15 +20,15 @@ const illustrations = {
   alert: ImgAlert,
   assignees: ImgAssignees,
   average: ImgAverage,
-  "checked-facility": ImgCheckedFacility,
+  'checked-facility': ImgCheckedFacility,
   checklist: ImgChecklist,
   facility: ImgFacility,
   pending: ImgPending,
   resolved: ImgResolved,
   scheduled: ImgScheduled,
-  "tutorial-01": ImgTutorial01,
-  "tutorial-02": ImgTutorial02,
-  "tutorial-03": ImgTutorial03,
+  'tutorial-01': ImgTutorial01,
+  'tutorial-02': ImgTutorial02,
+  'tutorial-03': ImgTutorial03,
   upgrade: ImgUpgrade,
 };
 

--- a/packages/shopl-assets/src/illustrations/generated/index.ts
+++ b/packages/shopl-assets/src/illustrations/generated/index.ts
@@ -1,41 +1,41 @@
-import ImgSettingAttendance from "./ImgSettingAttendance";
-import ImgSettingBoard from "./ImgSettingBoard";
-import ImgSettingChat from "./ImgSettingChat";
-import ImgSettingDisplay from "./ImgSettingDisplay";
-import ImgSettingExpenses from "./ImgSettingExpenses";
-import ImgSettingInventory from "./ImgSettingInventory";
-import ImgSettingJp from "./ImgSettingJp";
-import ImgSettingNs from "./ImgSettingNs";
-import ImgSettingPrice from "./ImgSettingPrice";
-import ImgSettingReport from "./ImgSettingReport";
-import ImgSettingSales from "./ImgSettingSales";
-import ImgSettingSchedule from "./ImgSettingSchedule";
-import ImgSettingTarget from "./ImgSettingTarget";
-import ImgSettingTodo from "./ImgSettingTodo";
-import ImgUpgradeBasic from "./ImgUpgradeBasic";
-import ImgUpgradeEnterprise from "./ImgUpgradeEnterprise";
-import ImgUpgradePro from "./ImgUpgradePro";
-import ImgUpgradeStandard from "./ImgUpgradeStandard";
+import ImgSettingAttendance from './ImgSettingAttendance';
+import ImgSettingBoard from './ImgSettingBoard';
+import ImgSettingChat from './ImgSettingChat';
+import ImgSettingDisplay from './ImgSettingDisplay';
+import ImgSettingExpenses from './ImgSettingExpenses';
+import ImgSettingInventory from './ImgSettingInventory';
+import ImgSettingJp from './ImgSettingJp';
+import ImgSettingNs from './ImgSettingNs';
+import ImgSettingPrice from './ImgSettingPrice';
+import ImgSettingReport from './ImgSettingReport';
+import ImgSettingSales from './ImgSettingSales';
+import ImgSettingSchedule from './ImgSettingSchedule';
+import ImgSettingTarget from './ImgSettingTarget';
+import ImgSettingTodo from './ImgSettingTodo';
+import ImgUpgradeBasic from './ImgUpgradeBasic';
+import ImgUpgradeEnterprise from './ImgUpgradeEnterprise';
+import ImgUpgradePro from './ImgUpgradePro';
+import ImgUpgradeStandard from './ImgUpgradeStandard';
 
 const illustrations = {
-  "setting-attendance": ImgSettingAttendance,
-  "setting-board": ImgSettingBoard,
-  "setting-chat": ImgSettingChat,
-  "setting-display": ImgSettingDisplay,
-  "setting-expenses": ImgSettingExpenses,
-  "setting-inventory": ImgSettingInventory,
-  "setting-jp": ImgSettingJp,
-  "setting-ns": ImgSettingNs,
-  "setting-price": ImgSettingPrice,
-  "setting-report": ImgSettingReport,
-  "setting-sales": ImgSettingSales,
-  "setting-schedule": ImgSettingSchedule,
-  "setting-target": ImgSettingTarget,
-  "setting-todo": ImgSettingTodo,
-  "upgrade-basic": ImgUpgradeBasic,
-  "upgrade-enterprise": ImgUpgradeEnterprise,
-  "upgrade-pro": ImgUpgradePro,
-  "upgrade-standard": ImgUpgradeStandard,
+  'setting-attendance': ImgSettingAttendance,
+  'setting-board': ImgSettingBoard,
+  'setting-chat': ImgSettingChat,
+  'setting-display': ImgSettingDisplay,
+  'setting-expenses': ImgSettingExpenses,
+  'setting-inventory': ImgSettingInventory,
+  'setting-jp': ImgSettingJp,
+  'setting-ns': ImgSettingNs,
+  'setting-price': ImgSettingPrice,
+  'setting-report': ImgSettingReport,
+  'setting-sales': ImgSettingSales,
+  'setting-schedule': ImgSettingSchedule,
+  'setting-target': ImgSettingTarget,
+  'setting-todo': ImgSettingTodo,
+  'upgrade-basic': ImgUpgradeBasic,
+  'upgrade-enterprise': ImgUpgradeEnterprise,
+  'upgrade-pro': ImgUpgradePro,
+  'upgrade-standard': ImgUpgradeStandard,
 };
 
 export type IllustrationNames = keyof typeof illustrations;


### PR DESCRIPTION
- forwardRef return type과 타입 불일치로 Lint Error 뜨는 이슈 수정

## 🔨작업 내용
Stack과 StackContainer ComponentType 이 forwardRef 리턴 타입과 불일치로 린트 에러가 발생했습니다.

<!-- 작업한 내용을 적어주세요. -->
- StackComponentType, StackContainerComponentType 수정
- createStackComponent 내부의 Stack 함수 제너릭 추가

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
