### PR TITLE
Update/useParentElementClick

### DIFF
--- a/.changeset/small-paws-give.md
+++ b/.changeset/small-paws-give.md
@@ -1,0 +1,6 @@
+---
+"@shoplflow/utils": patch
+"@shoplflow/base": patch
+---
+
+Update: useParentElementClick hook

--- a/packages/base/src/components/ScrollArea/ScrollArea.tsx
+++ b/packages/base/src/components/ScrollArea/ScrollArea.tsx
@@ -26,7 +26,6 @@ const ScrollArea = forwardRef<ScrollbarRefType, ScrollAreaProps>(({ children, ..
       {Boolean(windowWidth) && Boolean(windowHeight) && (
         <Scrollbars
           ref={mergeRef}
-          {...rest}
           autoHide
           autoHideTimeout={1000}
           autoHideDuration={200}

--- a/packages/utils/src/hooks/useParentElementClick.ts
+++ b/packages/utils/src/hooks/useParentElementClick.ts
@@ -61,6 +61,7 @@ export const useParentElementClick = <T extends HTMLElement>(onClickOutside: (ta
 
   const handleClick = useCallback(
     (e: Event) => {
+      e.stopPropagation();
       const parentNode = ref.current?.parentNode;
       if (parentNode && !ref.current?.contains(e.target as Node)) {
         onClickOutside(e.target);


### PR DESCRIPTION
## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->
- 팝오버 > 모달로 화면 노출 시, 모달 닫을 경우 팝오버까지 닫히는 이슈 발생
- useParentElementClick에 event.stopPropagation()을 추가

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
