### PR TITLE
update: TitleGroup Header 영역에 IconButton 영역 추가했습니다.

### DIFF
--- a/.changeset/calm-taxis-obey.md
+++ b/.changeset/calm-taxis-obey.md
@@ -1,0 +1,5 @@
+---
+"@shoplflow/templates": patch
+---
+
+TitleGroup 헤더 영역에 iconButton 컴포넌트 영역 추가

--- a/packages/templates/src/components/TitleGroup/TitleGroup.stories.tsx
+++ b/packages/templates/src/components/TitleGroup/TitleGroup.stories.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
 import type { StoryFn } from '@storybook/react';
-import { Button, colorTokens, Stack, Switch } from '@shoplflow/base';
+import { Button, colorTokens, Icon, Stack, Switch, IconButton } from '@shoplflow/base';
 import TitleGroup from './TitleGroup';
 import type { TitleGroupHeaderProps, TitleGroupHelpIconProps, TitleGroupProps } from './TitleGroup.types';
+import { EditIcon } from '@shoplflow/shopl-assets';
 
 interface PlaygroundProps extends TitleGroupProps, TitleGroupHeaderProps, TitleGroupHelpIconProps {
   showActions: boolean;
@@ -47,6 +48,11 @@ export const Playground: StoryFn<PlaygroundProps> = (args) => {
             title='Title'
             count={args.count}
             isRequired={args.isRequired}
+            rightIconButton={
+              <IconButton>
+                <Icon iconSource={EditIcon} />
+              </IconButton>
+            }
             helpIconProps={{
               tooltipPlacement: args.tooltipPlacement,
               tooltipOffsetValue: 4,

--- a/packages/templates/src/components/TitleGroup/TitleGroup.tsx
+++ b/packages/templates/src/components/TitleGroup/TitleGroup.tsx
@@ -41,7 +41,7 @@ const HeaderBox = ({ children }: ChildrenProps) => {
     </StackContainer.Horizontal>
   );
 };
-const Header = ({ depth, title, isRequired, count, helpIconProps }: TitleGroupHeaderProps) => {
+const Header = ({ depth, title, isRequired, count, helpIconProps, rightIconButton }: TitleGroupHeaderProps) => {
   const { color, typography } = getTypographyAndColor(depth);
   return (
     <Stack.Horizontal align='center'>
@@ -56,6 +56,7 @@ const Header = ({ depth, title, isRequired, count, helpIconProps }: TitleGroupHe
           </Text>
         )}
       </Stack.Horizontal>
+      {rightIconButton}
       {helpIconProps && <TitleGroupHelpIcon {...helpIconProps} />}
     </Stack.Horizontal>
   );

--- a/packages/templates/src/components/TitleGroup/TitleGroup.types.ts
+++ b/packages/templates/src/components/TitleGroup/TitleGroup.types.ts
@@ -1,6 +1,6 @@
-import type { TextProps, TooltipProps } from '@shoplflow/base';
+import type { IconButton, TextProps, TooltipProps, IconButtonProps } from '@shoplflow/base';
 import type { ChildrenProps } from '@shoplflow/base/src/utils/type/ComponentProps';
-import type { ReactNode } from 'react';
+import type { ReactNode, ReactElement } from 'react';
 
 export type ActionsProps = {
   children: ReactNode;
@@ -62,6 +62,7 @@ export type TitleGroupHeaderProps = {
    */
   isRequired?: boolean;
   helpIconProps?: TitleGroupHelpIconProps;
+  rightIconButton?: ReactElement<IconButtonProps, typeof IconButton>;
 };
 
 export interface TitleGroupProps extends ChildrenProps {}


### PR DESCRIPTION
- 기존에는 helpicon만 들어가도록 정의했지만 이번에 설정고도화 쪽에서 아이콘버튼이 필요하다고 진과 정의

## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->
- TitleGroup Header영역에 IconButton영역 추가

<!-- 관련있는 이슈 번호(#000)를 PR 제목에 적어주세요. -->

<!-- ex) [SF-1234] 무슨 기능 업데이트 -->

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

![image](https://github.com/user-attachments/assets/cc1ed9e8-f3fb-4fc3-98f4-bf9bd79cea5a)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
