### PR TITLE
chore: Slider component export 방식 변경

### DIFF
--- a/.changeset/gold-beans-play.md
+++ b/.changeset/gold-beans-play.md
@@ -1,0 +1,5 @@
+---
+"@shoplflow/base": minor
+---
+
+Slider의 export 방식을 변경했어요

--- a/packages/base/src/components/Slider/index.ts
+++ b/packages/base/src/components/Slider/index.ts
@@ -1,2 +1,2 @@
-export { default } from './Slider';
-export type { SliderProps } from './Slider.types';
+export { default as Slider } from './Slider';
+export * from './Slider.types';


### PR DESCRIPTION
## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->
shoplflow를 사용하는 곳에서 `Slider` component를 찾지 못하는 이슈가 있어 export 방식을 변경합니다
```typescript
export { default as Slider } from './Slider';
```

<!-- 관련있는 이슈 번호(#000)를 PR 제목에 적어주세요. -->

<!-- ex) [SF-1234] 무슨 기능 업데이트 -->

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [x] 머지 전에 빌드가 성공했나요?
- [x] 린트가 적용되어 있나요?
