### PR TITLE
update: Slider의 선택 범위 값을 외부에서 주입해 사용하도록 수정

### DIFF
--- a/.changeset/six-parrots-suffer.md
+++ b/.changeset/six-parrots-suffer.md
@@ -1,0 +1,5 @@
+---
+"@shoplflow/base": minor
+---
+
+Slider의 선택 범위를 외부에서 주입해 사용하도록 수정했어요

--- a/packages/base/src/components/Slider/Slider.mdx
+++ b/packages/base/src/components/Slider/Slider.mdx
@@ -8,9 +8,9 @@ import Slider from './Slider.tsx';
 
 지정된 단위에서 범위를 선택할 수 있는 슬라이더 컴포넌트입니다.
 
-> - `step`으로 증분 단위를 설정할 수 있습니다. 이 때 Slider의 최대값(`max`)을 벗어나면 에러가 발생합니다.
-> - 초기 선택 범위(`defaultRange`)를 설정할 때 Slider의 범위(`min` ~ `max`)를 벗어나면 에러가 발생합니다.
-> - thumb Button 위에 마우스 커서를 놓으면 현재 값이 tooltip으로 노출됩니다.
+> - `step`으로 증분 단위를 설정할 수 있으며, Slider의 최대값(`max`)을 벗어나면 에러가 발생합니다.
+> - 선택 범위(`range`)와 핸들러 함수(`handleRange`)를 외부에서 주입해 사용합니다. <br/>이 때 `range`가 Slider의 범위(`min` ~ `max`)를 벗어나면 에러가 발생합니다.
+> - thumb Button 위에 마우스 커서를 놓으면 현재 선택된 값의 절댓값이 tooltip으로 노출됩니다.
 
 ## Overview
 
@@ -22,11 +22,14 @@ import Slider from './Slider.tsx';
 import { Slider } from '@shoplflow/base';
 
 const Example = () => {
+  const [selectedRange, setSelectedRange] = useState({ min: 20, max: 60 });
+
   const handleChange = (range) => {
+    setSelectedRange(range);
     console.log('Selected range:', range);
   };
 
-  return <Slider max={100} defaultRange={{ min: 30, max: 60 }} onChange={handleChange} />;
+  return <Slider max={100} range={selectedRange} handleRange={handleChange} />;
 };
 ```
 

--- a/packages/base/src/components/Slider/Slider.stories.tsx
+++ b/packages/base/src/components/Slider/Slider.stories.tsx
@@ -7,17 +7,19 @@ import { useState } from 'react';
 import { Input } from '../Inputs';
 import { Text } from '../Text';
 import { StackContainer } from '../StackContainer';
+
 const SliderWrapper = styled.div`
   width: 500px;
 `;
 
 const SliderWithWrapper = (args: SliderProps) => {
-  const [currentRange, setCurrentRange] = useState(args.defaultRange);
+  const [currentRange, setCurrentRange] = useState(args.range);
 
   return (
     <SliderWrapper>
       <Slider
         {...args}
+        range={currentRange}
         handleRange={(range) => {
           setCurrentRange(range);
           args.handleRange?.(range);
@@ -51,9 +53,9 @@ const meta: Meta<typeof Slider> = {
       description: '증분 단위',
       defaultValue: 1,
     },
-    defaultRange: {
+    range: {
       control: 'object',
-      description: '초기 선택 범위',
+      description: '선택 범위',
     },
     isDisabled: {
       control: 'boolean',
@@ -81,7 +83,7 @@ export const Playground: Story = {
     min: 0,
     max: 100,
     step: 1,
-    defaultRange: { min: 50, max: 60 },
+    range: { min: 20, max: 60 },
     isDisabled: false,
     selectedColor: 'shopl300',
   },

--- a/packages/base/src/components/Slider/Slider.tsx
+++ b/packages/base/src/components/Slider/Slider.tsx
@@ -9,15 +9,15 @@ const Slider: React.FC<SliderProps> = ({
   min = 0,
   max,
   step = 1,
-  defaultRange = { min: 0, max: 0 },
+  range = { min: 0, max: 0 },
   handleRange,
   isDisabled = false,
   selectedColor = 'shopl300',
 }) => {
-  const { range, trackRef, handleMouseDown, handleClickTrack, positions } = useSlider({
+  const { selectedRange, trackRef, handleMouseDown, handleClickTrack, positions } = useSlider({
     bounds: { min, max },
     step,
-    defaultRange,
+    range,
     handleRange,
     isDisabled,
   });
@@ -25,7 +25,7 @@ const Slider: React.FC<SliderProps> = ({
   return (
     <SliderContainer isDisabled={isDisabled}>
       <SliderTrack ref={trackRef} onClick={handleClickTrack}>
-        <SliderSteps bounds={{ min, max }} step={step} range={range} />
+        <SliderSteps bounds={{ min, max }} step={step} />
         <SelectedTrack
           selectedColor={selectedColor}
           startPosition={`calc(${positions.start}% - 12px)`} //thumb을 완전히 감싸는 UI 구현을 위해 -12px
@@ -36,7 +36,7 @@ const Slider: React.FC<SliderProps> = ({
           isDisabled={isDisabled}
           selectedColor={selectedColor}
           onMouseDown={handleMouseDown}
-          values={range}
+          values={selectedRange}
         />
       </SliderTrack>
     </SliderContainer>

--- a/packages/base/src/components/Slider/Slider.types.ts
+++ b/packages/base/src/components/Slider/Slider.types.ts
@@ -16,7 +16,7 @@ export interface SliderProps {
   /**
    * 초기 선택 범위
    */
-  defaultRange?: { min: number; max: number };
+  range?: { min: number; max: number };
   /**
    * 선택 범위가 변경될 때 실행할 함수
    */

--- a/packages/base/src/components/Slider/SliderSteps.tsx
+++ b/packages/base/src/components/Slider/SliderSteps.tsx
@@ -6,7 +6,6 @@ import type { SliderBounds } from './Slider.types';
 interface SliderStepsProps {
   bounds: SliderBounds;
   step: number;
-  range: [number, number];
   maxSteps?: number;
 }
 

--- a/packages/base/src/components/Slider/sliderUtils.ts
+++ b/packages/base/src/components/Slider/sliderUtils.ts
@@ -79,22 +79,22 @@ export const generateSteps = (bounds: SliderBounds, step: number, maxSteps = 21)
  *
  * @param min - 슬라이더의 최소값
  * @param max - 슬라이더의 최대값
- * @param defaultRange - 슬라이더의 초기 선택 범위 { min, max }
+ * @param range - 슬라이더의 선택 범위 { min, max }
  */
 export const validateRange = ({
   min,
   max,
-  defaultRange,
+  range,
 }: {
   min: number;
   max: number;
-  defaultRange: { min: number; max: number };
+  range: { min: number; max: number };
 }) => {
-  if (defaultRange.min < min || defaultRange.max > max) {
-    throw new Error('defaultRange가 Slider의 전체 범위를 벗어납니다.');
+  if (range.min < min || range.max > max) {
+    throw new Error('range가 Slider의 전체 범위를 벗어납니다.');
   }
-  if (defaultRange.min > defaultRange.max) {
-    throw new Error('defaultRange가 올바르지 않습니다. 다시 확인해주세요.');
+  if (range.min > range.max) {
+    throw new Error('range가 올바르지 않습니다. 다시 확인해주세요.');
   }
 };
 

--- a/packages/base/src/components/Slider/useSlider.ts
+++ b/packages/base/src/components/Slider/useSlider.ts
@@ -1,41 +1,34 @@
-import { useState, useRef, useCallback } from 'react';
+import { useRef, useCallback, useMemo } from 'react';
 import { getPositionPercentage, getValueFromPercentage, validateRange, validateStep } from './sliderUtils';
 import type { SliderBounds } from './Slider.types';
 
 interface UseSliderProps {
   bounds: SliderBounds;
   step: number;
-  defaultRange: { min: number; max: number };
+  range: { min: number; max: number };
   handleRange?: (range: { min: number; max: number }) => void;
   isDisabled?: boolean;
 }
 
-export const useSlider = ({ bounds, step, defaultRange, handleRange, isDisabled = false }: UseSliderProps) => {
+export const useSlider = ({ bounds, step, range, handleRange, isDisabled = false }: UseSliderProps) => {
   const { min, max } = bounds;
   // 유효성 검증
-  validateRange({ min, max, defaultRange });
+  validateRange({ min, max, range });
   validateStep({ min, max, step });
 
-  const [range, setRange] = useState<[number, number]>([defaultRange.min, defaultRange.max]);
   const trackRef = useRef<HTMLDivElement>(null);
 
   const updateRange = useCallback(
     (index: number, newValue: number) => {
-      setRange((prev) => {
-        const newRange = [...prev] as [number, number];
-        // 첫 번째 thumb가 두 번째 thumb를 넘어가지 않도록 처리
-        if (index === 0) {
-          newRange[0] = Math.min(newValue, newRange[1]);
-        }
-        // 두 번째 thumb가 첫 번째 thumb 아래로 내려가지 않도록 처리
-        else if (index === 1) {
-          newRange[1] = Math.max(newValue, newRange[0]);
-        }
-        handleRange?.({ min: newRange[0], max: newRange[1] });
-        return newRange;
-      });
+      const newRange = [range.min, range.max] as [number, number];
+      if (index === 0) {
+        newRange[0] = Math.min(newValue, newRange[1]);
+      } else if (index === 1) {
+        newRange[1] = Math.max(newValue, newRange[0]);
+      }
+      handleRange?.({ min: newRange[0], max: newRange[1] });
     },
-    [handleRange],
+    [range, handleRange],
   );
 
   // 드래그 이벤트 처리
@@ -82,8 +75,8 @@ export const useSlider = ({ bounds, step, defaultRange, handleRange, isDisabled 
       const newValue = getValueFromPercentage(percentage, { min, max }, step);
 
       // 클릭한 위치가 어떤 썸에 더 가까운지 결정
-      const distanceToStart = Math.abs(getPositionPercentage(0, range, { min, max }) - percentage);
-      const distanceToEnd = Math.abs(getPositionPercentage(1, range, { min, max }) - percentage);
+      const distanceToStart = Math.abs(getPositionPercentage(0, [range.min, range.max], { min, max }) - percentage);
+      const distanceToEnd = Math.abs(getPositionPercentage(1, [range.min, range.max], { min, max }) - percentage);
 
       if (distanceToStart <= distanceToEnd) {
         updateRange(0, newValue);
@@ -94,20 +87,24 @@ export const useSlider = ({ bounds, step, defaultRange, handleRange, isDisabled 
     [isDisabled, min, max, step, range, updateRange],
   );
 
-  // 위치 계산
-  const startPosition = getPositionPercentage(0, range, { min, max });
-  const endPosition = getPositionPercentage(1, range, { min, max });
-  const width = endPosition - startPosition;
+  // 위치 계산을 useMemo로 감싸서 range가 변경될 때마다 다시 계산되도록 수정
+  const positions = useMemo(() => {
+    const startPosition = getPositionPercentage(0, [range.min, range.max], { min, max });
+    const endPosition = getPositionPercentage(1, [range.min, range.max], { min, max });
+    const width = endPosition - startPosition;
 
-  return {
-    range,
-    trackRef,
-    handleMouseDown,
-    handleClickTrack,
-    positions: {
+    return {
       start: startPosition,
       end: endPosition,
       width,
-    },
+    };
+  }, [range, min, max]);
+
+  return {
+    selectedRange: [range.min, range.max],
+    trackRef,
+    handleMouseDown,
+    handleClickTrack,
+    positions,
   };
 };


### PR DESCRIPTION
## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->
- Slider의 선택 범위 값을 외부에서 주입해 사용하도록 수정
- 변경된 prop에 맞게 Slider 스토리 수정

<!-- 관련있는 이슈 번호(#000)를 PR 제목에 적어주세요. -->

<!-- ex) [SF-1234] 무슨 기능 업데이트 -->

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [x] 머지 전에 빌드가 성공했나요?
- [x] 린트가 적용되어 있나요?
