### PR TITLE
update: Pagination sizeVar='XS'일때 아이콘에 크기까지 같이 반영

### DIFF
--- a/.changeset/strange-pears-allow.md
+++ b/.changeset/strange-pears-allow.md
@@ -1,0 +1,5 @@
+---
+"@shoplflow/base": patch
+---
+
+Pagination SizeVar='XS'일 때 아이콘 사이즈 제대로 반영안되는 현상 수정

--- a/packages/base/src/components/Pagination/Pagination.tsx
+++ b/packages/base/src/components/Pagination/Pagination.tsx
@@ -27,6 +27,9 @@ const Pagination = ({
   const responsiveClassName = isHadaDomain ? 'hada-responsive' : '';
   const isXSSize = sizeVar === 'XS';
 
+  // XS 사이즈일 때 Icon 스타일 정의
+  const iconStyle = isXSSize ? { width: '12px', height: '12px' } : undefined;
+
   const pageTotalCount = totalCount ?? Math.ceil(itemsTotalCount / Number(pageSize));
   const showLeftEllipsis = currentPage > pageCount - 1;
   const showRightEllipsis =
@@ -45,7 +48,7 @@ const Pagination = ({
           </IconButton>
         )}
         <IconButton sizeVar={sizeVar} styleVar='GHOST' onClick={previousPage} disabled={!canPreviousPage}>
-          <Icon iconSource={LeftArrowIcon} color='neutral400' sizeVar='S' />
+          <Icon iconSource={LeftArrowIcon} color='neutral400' sizeVar={sizeVar} style={iconStyle} />
         </IconButton>
 
         {showLeftEllipsis && (
@@ -78,7 +81,7 @@ const Pagination = ({
         )}
 
         <IconButton sizeVar={sizeVar} styleVar='GHOST' onClick={nextPage} disabled={!canNextPage}>
-          <Icon iconSource={RightArrowIcon} color='neutral400' sizeVar='S' />
+          <Icon iconSource={RightArrowIcon} color='neutral400' sizeVar={sizeVar} style={iconStyle} />
         </IconButton>
 
         {!isXSSize && (


### PR DESCRIPTION

## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->

- Pagination 컴포넌트에서 Pagination SizeVar='XS'일 때 아이콘 사이즈가 제대로 반영되지 않는 현상 수정

<!-- 관련있는 이슈 번호(#000)를 PR 제목에 적어주세요. -->

<!-- ex) [SF-1234] 무슨 기능 업데이트 -->

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
