### PR TITLE
update: onError대신 fallbackUrl을 사용하도록 수정

### DIFF
--- a/.changeset/witty-kings-fail.md
+++ b/.changeset/witty-kings-fail.md
@@ -1,0 +1,5 @@
+---
+"@shoplflow/base": patch
+---
+
+update: onError대신 fallbackUrl 사용

--- a/packages/base/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/base/src/components/Avatar/Avatar.stories.tsx
@@ -7,7 +7,6 @@ import type { AvatarProps } from './Avatar.types';
 import { Icon } from '../Icon';
 import { LeaderLargeIcon } from '@shoplflow/shopl-assets';
 import { Text } from '../Text';
-import AvatarImageNone from '../../assets/mocks/AvatarNone.png';
 
 export default {
   title: 'COMPONENTS/Avatar',
@@ -63,5 +62,5 @@ export const CompareNormalAndError: StoryFn<AvatarProps> = (args) => {
 
 CompareNormalAndError.args = {
   sizeVar: 'L',
-  fallbackUrl: AvatarImageNone,
+  fallbackUrl: undefined,
 };

--- a/packages/base/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/base/src/components/Avatar/Avatar.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import type { StoryFn } from '@storybook/react';
 import { Stack } from '../Stack';
@@ -7,6 +7,7 @@ import type { AvatarProps } from './Avatar.types';
 import { Icon } from '../Icon';
 import { LeaderLargeIcon } from '@shoplflow/shopl-assets';
 import { Text } from '../Text';
+import AvatarImageNone from '../../assets/mocks/AvatarNone.png';
 
 export default {
   title: 'COMPONENTS/Avatar',
@@ -37,30 +38,30 @@ WidthBadge.args = {
   sizeVar: 'M',
 };
 
-export const WithOnError: StoryFn<AvatarProps> = (args) => {
-  const [errorMessage, setErrorMessage] = useState<string>('');
-
-  const handleError = (event: React.SyntheticEvent<HTMLImageElement, Event>) => {
-    setErrorMessage('이미지 로드에 실패했습니다.');
-    // eslint-disable-next-line no-console
-    console.log('Avatar 이미지 로드 실패:', event);
-  };
-
+export const CompareNormalAndError: StoryFn<AvatarProps> = (args) => {
   return (
     <Stack direction='column' spacing='spacing16'>
-      <Text typography='body2_700'>onError 테스트 - 잘못된 이미지 URL 사용</Text>
-      <Stack>
-        <Avatar src='https://invalid-url-that-will-fail.com/image.jpg' onError={handleError} sizeVar='L' {...args} />
+      <Text typography='body2_700'>정상 이미지 vs 에러 이미지 비교</Text>
+      <Stack spacing='spacing16'>
+        <Stack direction='column' spacing='spacing08' align='center' width='100%'>
+          <Avatar src='https://picsum.photos/100/100' sizeVar='L' {...args} />
+          <Text typography='caption_400' color='green300'>
+            정상 이미지
+          </Text>
+        </Stack>
+
+        <Stack direction='column' spacing='spacing08' align='center' width='100%'>
+          <Avatar src='https://invalid-url-that-will-fail.com/image.jpg' sizeVar='L' {...args} />
+          <Text typography='caption_400' color='red300'>
+            에러 이미지 (fallback 표시)
+          </Text>
+        </Stack>
       </Stack>
-      {errorMessage && (
-        <Text typography='caption_400' color='red300'>
-          {errorMessage}
-        </Text>
-      )}
     </Stack>
   );
 };
 
-WithOnError.args = {
+CompareNormalAndError.args = {
   sizeVar: 'L',
+  fallbackUrl: AvatarImageNone,
 };

--- a/packages/base/src/components/Avatar/Avatar.tsx
+++ b/packages/base/src/components/Avatar/Avatar.tsx
@@ -11,6 +11,7 @@ const Avatar = ({ src, badge, fallbackUrl, ...rest }: AvatarProps): JSX.Element 
         <StyledAvatarImage
           src={src ?? fallbackUrl}
           onError={(e) => {
+            // @ts-ignore: allow string | StaticImageData assignment
             e.currentTarget.src = fallbackUrl ?? AvatarImageNone;
           }}
         />

--- a/packages/base/src/components/Avatar/Avatar.tsx
+++ b/packages/base/src/components/Avatar/Avatar.tsx
@@ -3,7 +3,7 @@ import { StyledAvatar, StyledAvatarBadge, StyledAvatarContainer, StyledAvatarIma
 import type { AvatarProps } from './Avatar.types';
 import AvatarImageNone from '../../assets/mocks/AvatarNone.png';
 
-const Avatar = ({ src, badge, fallbackUrl = AvatarImageNone, ...rest }: AvatarProps): JSX.Element => {
+const Avatar = ({ src, badge, fallbackUrl, ...rest }: AvatarProps): JSX.Element => {
   return (
     <StyledAvatarContainer>
       <StyledAvatar data-shoplflow={'Avatar'} {...rest}>
@@ -11,7 +11,7 @@ const Avatar = ({ src, badge, fallbackUrl = AvatarImageNone, ...rest }: AvatarPr
         <StyledAvatarImage
           src={src ?? fallbackUrl}
           onError={(e) => {
-            e.currentTarget.src = fallbackUrl;
+            e.currentTarget.src = fallbackUrl ?? AvatarImageNone;
           }}
         />
       </StyledAvatar>

--- a/packages/base/src/components/Avatar/Avatar.tsx
+++ b/packages/base/src/components/Avatar/Avatar.tsx
@@ -3,12 +3,17 @@ import { StyledAvatar, StyledAvatarBadge, StyledAvatarContainer, StyledAvatarIma
 import type { AvatarProps } from './Avatar.types';
 import AvatarImageNone from '../../assets/mocks/AvatarNone.png';
 
-const Avatar = ({ src, badge, onError, ...rest }: AvatarProps): JSX.Element => {
+const Avatar = ({ src, badge, fallbackUrl = AvatarImageNone, ...rest }: AvatarProps): JSX.Element => {
   return (
     <StyledAvatarContainer>
       <StyledAvatar data-shoplflow={'Avatar'} {...rest}>
         {/*eslint-disable-next-line @typescript-eslint/no-unsafe-assignment*/}
-        <StyledAvatarImage src={(src ?? AvatarImageNone) as string} onError={onError} />
+        <StyledAvatarImage
+          src={src ?? fallbackUrl}
+          onError={(e) => {
+            e.currentTarget.src = fallbackUrl;
+          }}
+        />
       </StyledAvatar>
       <StyledAvatarBadge>{badge}</StyledAvatarBadge>
     </StyledAvatarContainer>

--- a/packages/base/src/components/Avatar/Avatar.types.ts
+++ b/packages/base/src/components/Avatar/Avatar.types.ts
@@ -12,7 +12,9 @@ export const AvatarSizeVariants = {
 
 export type AvatarSizeVariantType = $Values<typeof AvatarSizeVariants>;
 
-export interface AvatarProps extends AvatarOptionProps {}
+export interface AvatarProps extends AvatarOptionProps {
+  fallbackUrl?: string;
+}
 export interface AvatarOptionProps
   extends SizeVariantProps<AvatarSizeVariantType>,
     ImgHTMLAttributes<HTMLImageElement> {


### PR DESCRIPTION
## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->

- fallbackUrl을 default 이미지 지정

<!-- 관련있는 이슈 번호(#000)를 PR 제목에 적어주세요. -->

<!-- ex) [SF-1234] 무슨 기능 업데이트 -->

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
