### PR TITLE
fix: 디자인 승인 배포 워크플로 수정 (GITHUB_TOKEN 추가, 두 버튼 구조 복원)

### DIFF
--- a/.github/workflows/design-approved-deploy.yml
+++ b/.github/workflows/design-approved-deploy.yml
@@ -77,6 +77,8 @@ jobs:
         run: pnpm install
 
       - name: changeset version (버전 범프 + changeset 소비)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if ls .changeset/*.md 1>/dev/null 2>&1; then
             pnpm run version

--- a/workers/slack-design-approved/README.md
+++ b/workers/slack-design-approved/README.md
@@ -2,8 +2,8 @@
 
 Slack 메시지의 인터랙션을 처리하는 Cloudflare Worker.
 
-- **디자인 검수 완료**(초록): 검수 완료 안내 메시지만 채널에 표시 (배포 없음)
-- **배포**(빨강): `workflow_dispatch(ref=main, inputs.branch=기능브랜치)` → `design-approved-deploy`가 기능 브랜치를 `main`에 머지·푸시 → `changesets-workflow.yml`가 main push 시 npm 배포
+- **디자인 검수 완료**(`action_id: design_approved`): 검수 완료 안내 메시지 표시 (배포 없음)
+- **배포**(`action_id: design_deploy`): `workflow_dispatch(ref=main, inputs.branch=기능브랜치)` → `design-approved-deploy`가 기능 브랜치를 `main`에 머지·버전 범프·푸시 → `changesets-workflow.yml`가 npm 배포
 
 ## 배포 방법
 
@@ -54,4 +54,4 @@ pnpm send-design-review https://xxx-xxxxx.chromatic.com/
 ```
 
 위 URL은 Chromatic 실행 시 터미널에 나오는 "View your Storybook at ..." 주소를 사용한다.  
-디자이너는 먼저 **디자인 검수 완료**로 검수를 기록한 뒤, 배포를 진행할 때만 **배포**를 누른다.
+디자이너가 **디자인 검수 완료**로 검수를 기록한 뒤, **배포** 버튼을 누르면 main 머지 + npm 배포까지 자동 진행된다.

--- a/workers/slack-design-approved/index.js
+++ b/workers/slack-design-approved/index.js
@@ -2,9 +2,10 @@
  * Slack Interactivity Webhook → GitHub workflow_dispatch
  *
  * 디자이너가 Slack에서 버튼을 누르면 이 Worker가:
- * - "디자인 검수 완료": 채널에 검수 완료 안내 메시지 (배포 없음)
- * - "배포": workflow_dispatch(ref=main, inputs.branch=기능브랜치) → design-approved-deploy가
- *   기능 브랜치를 main에 머지·푸시 → Changesets 워크플로가 npm 배포
+ * - "디자인 검수 완료"(action_id: design_approved): 검수 완료 안내 메시지 표시 (배포 없음)
+ * - "배포"(action_id: design_deploy): workflow_dispatch(ref=main, inputs.branch=기능브랜치)
+ *   → design-approved-deploy가 기능 브랜치를 main에 머지·버전 범프·푸시
+ *   → Changesets 워크플로가 npm 배포
  *
  * 필요 Worker Secrets:
  *   SLACK_SIGNING_SECRET  - Slack App의 Signing Secret
@@ -126,9 +127,8 @@ export default {
 
     const actionId = action.action_id;
 
-    // 검수 완료만 표시 — GitHub 호출 없음
-    if (actionId === 'design_review_complete') {
-      const text = `✅ ${mention ? `${mention} ` : ''}*디자인 검수 완료*로 표시했습니다. 이 브랜치를 바로 빌드·배포하려면 아래 *배포* 버튼을 눌러주세요. (\`${branch}\`)`;
+    if (actionId === 'design_approved') {
+      const text = `✅ ${mention ? `${mention} ` : ''}*디자인 검수 완료* — \`${branch}\` 브랜치의 디자인 검수가 완료되었습니다. 배포하려면 *배포* 버튼을 눌러주세요.`;
       const messagePayload = {
         replace_original: false,
         response_type: 'in_channel',


### PR DESCRIPTION
## Summary
- `design-approved-deploy.yml`의 changeset version 스텝에 `GITHUB_TOKEN` 환경변수 추가 (`@changesets/changelog-github`가 changelog 생성 시 필요)
- Worker: `design_approved`(검수 완료 안내) + `design_deploy`(배포) 두 버튼 구조 복원

## Test plan
- [x] Slack 버튼 2개(디자인 검수 완료, 배포) 정상 표시 확인
- [x] Worker 배포 완료
- [ ] main 머지 후 배포 버튼 클릭 시 workflow_dispatch → changeset version 정상 동작 확인

Made with [Cursor](https://cursor.com)