### PR TITLE
fix: CI changeset version 커밋 시 --no-verify 추가

### DIFF
--- a/.github/workflows/design-approved-deploy.yml
+++ b/.github/workflows/design-approved-deploy.yml
@@ -83,7 +83,7 @@ jobs:
           if ls .changeset/*.md 1>/dev/null 2>&1; then
             pnpm run version
             git add -A
-            git commit -m "ci(changesets): version packages (디자인 승인 배포)"
+            git commit --no-verify -m "ci(changesets): version packages (디자인 승인 배포)"
           else
             echo "소비할 changeset 파일이 없습니다. 버전 범프를 건너뜁니다."
           fi


### PR DESCRIPTION
## Summary
- `design-approved-deploy.yml`의 changeset version 자동 커밋에 `--no-verify` 추가
- CI에서 assets 미빌드 상태로 pre-commit 훅(type-check)이 실패하는 문제 해결
- 빌드 검증은 바로 다음 `pnpm build` 스텝에서 수행하므로 안전

## Test plan
- [ ] 배포 버튼 클릭 시 changeset version 커밋이 훅 없이 정상 생성되는지 확인

Made with [Cursor](https://cursor.com)