### PR TITLE
fix(ci): 디자인 승인 배포 후 release 즉시 실행

### DIFF
--- a/.github/workflows/changesets-workflow.yml
+++ b/.github/workflows/changesets-workflow.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'main에 머지할 브랜치명'
+        description: "main에 머지할 브랜치명"
         required: true
         type: string
   push:
@@ -76,8 +76,8 @@ jobs:
       - name: Node 설정
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
 
       - name: 의존성 설치
         run: pnpm install
@@ -135,6 +135,60 @@ jobs:
           curl -s -X POST "${{ secrets.SLACK_WEBHOOK_URL }}" \
             -H "Content-Type: application/json" \
             -d "{\"text\": \"❌ *배포 실패* — \`$FEATURE\` → \`main\` 처리 중 오류가 발생했습니다. GitHub Actions 로그를 확인해주세요.\"}"
+
+  release-after-design-approval:
+    name: Release (디자인 승인 직후)
+    if: github.event_name == 'workflow_dispatch'
+    needs: [design-approved-merge]
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: changesets-release-dispatch-${{ github.repository }}
+      cancel-in-progress: false
+
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      NPM_CONFIG_PROVENANCE: "true"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: pnpm을 설정하고 있어요.
+        uses: pnpm/action-setup@v4
+
+      - name: 노드를 설정하고 있어요.
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: Ensure npm >= 11.5.1 for Trusted Publishing
+        run: npm i -g npm@^11.5.1
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: 패키지를 빌드하고 있어요.
+        run: pnpm build
+
+      - name: PR을 생성하거나 NPM에 배포하고 있어요.
+        uses: changesets/action@v1
+        with:
+          version: pnpm run version
+          publish: pnpm run release
+          commit: "ci(changesets): version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     name: Release


### PR DESCRIPTION
## 변경 내용
- `changesets-workflow.yml`에 `workflow_dispatch` 전용 release job(`release-after-design-approval`) 추가
- 디자인 승인 머지 성공 직후 같은 런에서 release가 실행되도록 구성
- 기존 push 기반 `release` job은 그대로 유지

## 배경
- 디자인 승인 job은 성공했지만, 후속 push 트리거에 의존하던 release가 스킵되는 케이스가 있어 배포가 지연됨
- `GITHUB_TOKEN` 유지 조건에서 확실하게 배포가 이어지도록 개선

## 확인 포인트
- workflow_dispatch 실행 시 `디자인 승인 — 버전 범프 → PR 머지` 다음 `Release (디자인 승인 직후)`가 실행되는지
- 기존 main push 시 `Release` job이 기존대로 동작하는지

Made with [Cursor](https://cursor.com)