### PR TITLE
fix(ci): 디자인 승인 배포에서 changeset 미변경 실패 방지

### DIFF
--- a/.github/workflows/changesets-workflow.yml
+++ b/.github/workflows/changesets-workflow.yml
@@ -91,8 +91,12 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add -A
-            git commit --no-verify -m "ci(changesets): version packages (디자인 승인 배포)"
-            git push origin ${{ inputs.branch }}
+            if git diff --cached --quiet; then
+              echo "changeset 처리 결과 커밋할 변경이 없습니다. 커밋/푸시를 건너뜁니다."
+            else
+              git commit --no-verify -m "ci(changesets): version packages (디자인 승인 배포)"
+              git push origin ${{ inputs.branch }}
+            fi
           else
             echo "소비할 changeset 파일이 없습니다. 버전 범프를 건너뜁니다."
           fi


### PR DESCRIPTION
## 변경 내용
- `changeset version` 단계에서 `git add -A` 이후 staged diff가 없으면 커밋/푸시를 건너뛰도록 처리
- unreleased changeset이 없는 상태에서도 워크플로가 실패하지 않고 다음 단계로 진행되도록 수정

## 배포 목적
- 현재 main은 `@shoplflow/base` 0.46.27로 올라갔지만 npm은 0.46.26 상태
- 본 수정을 main 반영 후 workflow_dispatch를 다시 실행해 0.46.27 publish를 완료하기 위함

Made with [Cursor](https://cursor.com)