### PR TITLE
SelectInputButton: 카운트 텍스트 Tag 컴포넌트로 변경, 클리어 버튼 위치 조정

### DIFF
--- a/.changeset/curly-adults-check.md
+++ b/.changeset/curly-adults-check.md
@@ -1,0 +1,5 @@
+---
+'@shoplflow/base': patch
+---
+
+SelectInputButton: 카운트 텍스트를 Tag 컴포넌트로 변경, 클리어 버튼 위치 조정

--- a/packages/base/src/components/Inputs/SelectInputButton/SelectInputButton.tsx
+++ b/packages/base/src/components/Inputs/SelectInputButton/SelectInputButton.tsx
@@ -7,6 +7,7 @@ import { assetFunction } from '../../../styles/IconAssets';
 import { Stack } from '../../Stack';
 import { InputWrapper } from '../common/input.styled';
 import { Text } from '../../Text';
+import { Tag } from '../../Tag';
 
 const SelectInputButton = ({
   disabled,
@@ -79,17 +80,17 @@ const SelectInputButton = ({
           </Text>
         )}
 
-        <Stack.Horizontal align={'center'} spacing={'spacing04'}>
-          {value && value.length > 1 && (
-            <Text typography={'body1_400'} color={getTextColor(disabled)} overflowWrap='normal'>
-              +{value.length - 1}
-            </Text>
+        <Stack.Horizontal align={'center'}>
+          {value && value.length > 0 && Boolean(onClear) && isHovered && (
+            <IconButton sizeVar={'S'} onClick={handleOnClear} styleVar={'GHOST'} disabled={disabled}>
+              <Icon iconSource={assetFunction('DeleteIcon')} color={'neutral350'} />
+            </IconButton>
           )}
-          <Stack.Horizontal align={'center'}>
-            {value && value.length > 0 && Boolean(onClear) && isHovered && (
-              <IconButton sizeVar={'S'} onClick={handleOnClear} styleVar={'GHOST'} disabled={disabled}>
-                <Icon iconSource={assetFunction('DeleteIcon')} color={'neutral350'} />
-              </IconButton>
+          <Stack.Horizontal align={'center'} spacing={'spacing04'}>
+            {value && value.length > 1 && (
+              <Tag styleVar='TINT' sizeVar='XS' background='neutral150'>
+                +{value.length - 1}
+              </Tag>
             )}
             {rightSource}
           </Stack.Horizontal>

--- a/packages/extension/public/manifest.json
+++ b/packages/extension/public/manifest.json
@@ -24,7 +24,7 @@
         "src/pages/content/index.js"
       ],
       "css": [
-        "assets/css/contentStyle17798638860.chunk.css"
+        "assets/css/contentStyle17816579601.chunk.css"
       ]
     }
   ],


### PR DESCRIPTION
## 변경 사항
- SelectInputButton의 `+{value.length - 1}` 카운트 텍스트를 `<Tag>` 컴포넌트로 변경
- 클리어 버튼 위치를 카운트 앞으로 조정

## 관련
- Chromatic: https://69afad58aa7c90fbf3c141ee-cnmqirwctc.chromatic.com/