### PR TITLE
feat(base): ToggleButton fullWidth·buttonLineClamp 추가, Button XS 로딩 사…

### DIFF
--- a/.changeset/button-xs-loading-size.md
+++ b/.changeset/button-xs-loading-size.md
@@ -1,0 +1,5 @@
+---
+'@shoplflow/base': patch
+---
+
+Button: XS 사이즈에서 로딩(isLoading) 노출 시 스피너가 텍스트보다 커서 버튼 높이가 늘어나던 문제 수정. 스피너 크기를 사이즈별 텍스트 줄높이에 맞춰(XS는 16px) 로딩 상태에서도 버튼 높이가 유지됩니다. (LoadingSpinner에 size prop 추가)

--- a/.changeset/togglebutton-fullwidth.md
+++ b/.changeset/togglebutton-fullwidth.md
@@ -1,0 +1,9 @@
+---
+'@shoplflow/base': minor
+'@shoplflow/mcp': patch
+---
+
+ToggleButton: fullWidth, buttonLineClamp prop 추가.
+
+- fullWidth: true이면 Wrapper가 부모 가용 너비를 100% 채우고 각 InnerRadio를 동일 비율(flex:1)로 분배합니다. fullWidth가 true일 때 fixedWidth는 생략 가능하고, fullWidth가 없으면 기존처럼 fixedWidth가 필수입니다(타입 레벨에서 강제).
+- buttonLineClamp: 값이 있으면 각 InnerRadio 라벨 텍스트를 지정한 줄 수로 제한(line-clamp)하고 말줄임(…) 처리합니다.

--- a/packages/base/src/assets/LoadingSpinner.tsx
+++ b/packages/base/src/assets/LoadingSpinner.tsx
@@ -3,11 +3,16 @@ import { colorTokens } from '../styles';
 
 interface LoadingSpinnerProps {
   color?: ColorTokens;
+  /**
+   * 스피너의 가로·세로 크기(px)입니다.
+   * @default 24
+   */
+  size?: number;
 }
 
-const LoadingSpinner = ({ color = 'neutral0' }: LoadingSpinnerProps) => {
+const LoadingSpinner = ({ color = 'neutral0', size = 24 }: LoadingSpinnerProps) => {
   return (
-    <svg width='24' height='24' stroke={colorTokens[color]} viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'>
+    <svg width={size} height={size} stroke={colorTokens[color]} viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'>
       <style>
         {`
           .spinner { transform-origin: center; animation: spinner_rotation 2s linear infinite; }

--- a/packages/base/src/components/Buttons/Button/Button.tsx
+++ b/packages/base/src/components/Buttons/Button/Button.tsx
@@ -30,6 +30,15 @@ const Button = forwardRef(
       return sizeVar === 'M' ? 'body1_400' : 'body2_400';
     };
 
+    // 로딩 스피너를 텍스트 줄높이에 맞춰, 로딩 노출 시에도 버튼 높이가 유지되도록 합니다.
+    const getSpinnerSize = () => {
+      if (sizeVar === 'XS') {
+        return 16;
+      }
+
+      return 24;
+    };
+
     return (
       <StyledButton
         styleVar={styleVar}
@@ -44,7 +53,10 @@ const Button = forwardRef(
       >
         {leftSource}
         {isLoading ? (
-          <LoadingSpinner color={styleVar === 'SECONDARY' || styleVar === 'GHOST' ? 'neutral500' : 'neutral0'} />
+          <LoadingSpinner
+            size={getSpinnerSize()}
+            color={styleVar === 'SECONDARY' || styleVar === 'GHOST' ? 'neutral500' : 'neutral0'}
+          />
         ) : (
           <Text
             lineClamp={lineClamp}

--- a/packages/base/src/components/ToggleButton/ToggleButton.stories.tsx
+++ b/packages/base/src/components/ToggleButton/ToggleButton.stories.tsx
@@ -15,6 +15,15 @@ const DEMO_VALUES = ['value1', 'value2', 'value3'] as const;
 
 /** 컴포넌트별 변경 이력 (최신이 위). 스토리 Docs에 표시됩니다. */
 const COMPONENT_CHANGELOG: ComponentChangelogEntry[] = [
+  {
+    version: '1.1',
+    date: '2026-06-23',
+    changes: [
+      'fullWidth prop 추가: Wrapper를 부모 너비 100%로 채우고 각 아이템을 동일 비율(flex:1)로 분배',
+      'fixedWidth를 fullWidth와 배타적으로 변경(fullWidth가 true면 선택, 아니면 필수)',
+      'buttonLineClamp prop 추가: 각 InnerRadio 라벨 텍스트를 지정한 줄 수로 제한(line-clamp)하고 말줄임 처리',
+    ],
+  },
   { version: '1.0', date: '2026-04-22', changes: ['Storybook Docs에 버전·Changelog 섹션 추가'] },
 ];
 
@@ -45,7 +54,17 @@ const meta: Meta<typeof ToggleButton> = {
     },
     fixedWidth: {
       control: { type: 'number' },
-      description: '각 아이템의 고정 너비(px)를 설정합니다.',
+      description: '각 아이템의 고정 너비(px)를 설정합니다. (fullWidth가 false일 때 필수)',
+    },
+    fullWidth: {
+      control: { type: 'boolean' },
+      description:
+        'true이면 Wrapper가 부모 가용 너비를 100% 채우고 각 아이템을 동일 비율(flex:1)로 분배합니다. 이 경우 fixedWidth는 무시됩니다.',
+    },
+    buttonLineClamp: {
+      control: { type: 'number' },
+      description:
+        '값이 있으면 각 InnerRadio 라벨 텍스트를 해당 줄 수로 제한하고 말줄임(…) 처리합니다. 너비가 제약되는 fullWidth 모드에서 가장 잘 동작합니다.',
     },
   },
   args: {
@@ -121,7 +140,7 @@ Playground.argTypes = {
 
 Playground.parameters = {
   controls: {
-    include: ['sizeVar', 'disabled', 'fixedWidth', 'demoSelectedValue', 'firstItemLabel'],
+    include: ['sizeVar', 'disabled', 'fixedWidth', 'fullWidth', 'demoSelectedValue', 'firstItemLabel'],
   },
   design: {
     type: 'figma',
@@ -184,6 +203,100 @@ ItemDisabled.args = {
 ItemDisabled.parameters = {
   controls: {
     include: ['sizeVar'],
+  },
+  design: {
+    type: 'figma',
+    url: FIGMA_URL,
+  },
+};
+
+export const FullWidth: StoryFn<ToggleButtonProps> = (args) => {
+  const [selectedValue, setSelectedValue] = useState<string>('value1');
+
+  const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    setSelectedValue(event.target.value);
+    args.onChange?.(event);
+  };
+
+  return (
+    <Stack spacing='spacing16'>
+      <Text>fullWidth=true: 부모 너비를 100% 채우고 각 아이템이 동일 비율(flex:1)로 분배됩니다.</Text>
+
+      {/* 부모 너비를 제한해 100% 채움을 시각적으로 확인하기 위한 컨테이너 */}
+      <div style={{ width: 480, border: '1px dashed #ccc' }}>
+        <ToggleButton
+          {...args}
+          fullWidth
+          selectedValue={selectedValue}
+          onChange={handleChange}
+          targetName='full-width-group'
+        >
+          <ToggleButton.InnerRadio value='value1' label='Toggle1Toggle1Toggle1Toggle1' id='full-width-1' />
+          <ToggleButton.InnerRadio value='value2' label='Toggle2 Toggle2Toggle2Toggle2' id='full-width-2' />
+          <ToggleButton.InnerRadio value='value3' label='Toggle3' id='full-width-3' />
+        </ToggleButton>
+      </div>
+    </Stack>
+  );
+};
+
+FullWidth.args = {
+  sizeVar: 'S',
+};
+
+FullWidth.parameters = {
+  controls: {
+    include: ['sizeVar', 'buttonLineClamp'],
+  },
+  design: {
+    type: 'figma',
+    url: FIGMA_URL,
+  },
+};
+
+export const ButtonLineClamp: StoryFn<ToggleButtonProps> = (args) => {
+  const [selectedValue, setSelectedValue] = useState<string>('value1');
+
+  const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    setSelectedValue(event.target.value);
+    args.onChange?.(event);
+  };
+
+  return (
+    <Stack spacing='spacing16'>
+      <Text>
+        buttonLineClamp: 라벨이 길어도 지정한 줄 수까지만 표시하고 말줄임(…) 처리합니다. (fullWidth와 함께 사용)
+      </Text>
+
+      <div style={{ width: 360, border: '1px dashed #ccc' }}>
+        <ToggleButton
+          {...args}
+          fullWidth
+          selectedValue={selectedValue}
+          onChange={handleChange}
+          targetName='line-clamp-group'
+        >
+          <ToggleButton.InnerRadio
+            value='value1'
+            label='아주 긴 라벨 텍스트 예시 첫번째 항목입니다'
+            id='line-clamp-1'
+          />
+          <ToggleButton.InnerRadio value='value2' label='두번째 항목도 라벨이 꽤 길어요' id='line-clamp-2' />
+          <ToggleButton.InnerRadio value='value3' label='짧은' id='line-clamp-3' />
+        </ToggleButton>
+      </div>
+    </Stack>
+  );
+};
+
+ButtonLineClamp.args = {
+  sizeVar: 'S',
+  buttonLineClamp: 1,
+};
+
+ButtonLineClamp.parameters = {
+  controls: {
+    include: ['sizeVar', 'buttonLineClamp'],
   },
   design: {
     type: 'figma',

--- a/packages/base/src/components/ToggleButton/ToggleButton.styled.ts
+++ b/packages/base/src/components/ToggleButton/ToggleButton.styled.ts
@@ -23,16 +23,24 @@ const getLabelStyleBySizeVar = (sizeVar: ToggleButtonSizeVariantType) => {
   }
 };
 
-export const StyledToggleButton = styled.div`
+export const StyledToggleButton = styled.div<{
+  fullWidth?: boolean;
+}>`
   display: flex;
   padding: ${spacingTokens.spacing04};
   align-items: stretch;
   background-color: ${colorTokens.neutral150};
   border-radius: ${borderRadiusTokens.borderRadius06};
+  ${({ fullWidth }) =>
+    fullWidth &&
+    css`
+      width: 100%;
+    `}
 `;
 
 export const StyledToggleInner = styled.button<{
-  width: number;
+  width?: number;
+  fullWidth?: boolean;
   sizeVar: ToggleButtonSizeVariantType;
 }>`
   width: fit-content;
@@ -41,11 +49,19 @@ export const StyledToggleInner = styled.button<{
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: ${({ width }) => `${width}px`};
+  min-width: ${({ width }) => (width !== undefined ? `${width}px` : undefined)};
   padding: 0 12px;
   border-radius: 6px;
   background-color: transparent;
   ${({ sizeVar }) => getLabelStyleBySizeVar(sizeVar)}
+
+  ${({ fullWidth }) =>
+    fullWidth &&
+    css`
+      flex: 1;
+      width: auto;
+      min-width: 0;
+    `}
 
   &[data-selected='true'] {
     cursor: default;
@@ -68,11 +84,22 @@ export const StyledToggleInner = styled.button<{
   }
 `;
 
-export const StyledToggleInnerLabel = styled.label`
+export const StyledToggleInnerLabel = styled.label<{
+  lineClamp?: number;
+}>`
   display: flex;
   align-items: center;
   justify-content: center;
   background-color: transparent;
+  ${({ lineClamp }) =>
+    lineClamp &&
+    css`
+      min-width: 0;
+
+      & > * {
+        min-width: 0;
+      }
+    `}
 `;
 
 export const StyledToggleInnerInput = styled.input`

--- a/packages/base/src/components/ToggleButton/ToggleButton.tsx
+++ b/packages/base/src/components/ToggleButton/ToggleButton.tsx
@@ -11,6 +11,8 @@ import { ToggleButtonContext, useToggleButton } from './useToggleButton';
 
 const ToggleButton = ({
   fixedWidth,
+  fullWidth = false,
+  buttonLineClamp,
   children,
   targetName,
   onChange,
@@ -20,8 +22,10 @@ const ToggleButton = ({
   ...rest
 }: ToggleButtonProps) => {
   return (
-    <ToggleButtonContext.Provider value={{ fixedWidth, targetName, onChange, selectedValue, sizeVar, disabled }}>
-      <StyledToggleButton data-shoplflow={'ToggleButton'} aria-disabled={disabled} {...rest}>
+    <ToggleButtonContext.Provider
+      value={{ fixedWidth, fullWidth, buttonLineClamp, targetName, onChange, selectedValue, sizeVar, disabled }}
+    >
+      <StyledToggleButton data-shoplflow={'ToggleButton'} fullWidth={fullWidth} aria-disabled={disabled} {...rest}>
         {children}
       </StyledToggleButton>
     </ToggleButtonContext.Provider>
@@ -30,7 +34,16 @@ const ToggleButton = ({
 
 const ToggleInnerRadio = forwardRef<HTMLInputElement, ToggleButtonInnerRadioProps>(
   ({ label, disabled: itemDisabled, value, id, ...rest }, ref) => {
-    const { fixedWidth, onChange, targetName, selectedValue, sizeVar, disabled: groupDisabled } = useToggleButton();
+    const {
+      fixedWidth,
+      fullWidth,
+      buttonLineClamp,
+      onChange,
+      targetName,
+      selectedValue,
+      sizeVar,
+      disabled: groupDisabled,
+    } = useToggleButton();
 
     const disabled = groupDisabled || itemDisabled;
 
@@ -52,6 +65,7 @@ const ToggleInnerRadio = forwardRef<HTMLInputElement, ToggleButtonInnerRadioProp
     return (
       <StyledToggleInner
         width={fixedWidth}
+        fullWidth={fullWidth}
         sizeVar={sizeVar}
         type='button'
         aria-disabled={disabled}
@@ -66,7 +80,6 @@ const ToggleInnerRadio = forwardRef<HTMLInputElement, ToggleButtonInnerRadioProp
       >
         <StyledToggleInnerInput
           checked={selected}
-          width={fixedWidth}
           disabled={disabled}
           aria-disabled={disabled}
           value={value}
@@ -78,10 +91,12 @@ const ToggleInnerRadio = forwardRef<HTMLInputElement, ToggleButtonInnerRadioProp
           onChange={onChange}
         />
 
-        <StyledToggleInnerLabel ref={labelRef} htmlFor={id}>
+        <StyledToggleInnerLabel ref={labelRef} htmlFor={id} lineClamp={buttonLineClamp}>
           <Text
             color={getLabelColor({ selected, disabled: Boolean(disabled) })}
             wordBreak='break-all'
+            lineClamp={buttonLineClamp}
+            textAlign={buttonLineClamp ? 'center' : undefined}
             typography={selected ? 'body2_500' : 'body2_400'}
           >
             {label}

--- a/packages/base/src/components/ToggleButton/ToggleButton.types.ts
+++ b/packages/base/src/components/ToggleButton/ToggleButton.types.ts
@@ -8,14 +8,40 @@ export const ToggleButtonSizeVariants = {
 
 export type ToggleButtonSizeVariantType = $Values<typeof ToggleButtonSizeVariants>;
 
-export interface ToggleButtonProps extends ToggleButtonOptionProps, HTMLAttributes<HTMLDivElement> {
+interface ToggleButtonBaseProps extends ToggleButtonOptionProps, HTMLAttributes<HTMLDivElement> {
   targetName: string;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
-  fixedWidth: number;
   selectedValue?: string;
   sizeVar?: ToggleButtonSizeVariantType;
   disabled?: boolean;
+  /**
+   * 값이 있으면 각 InnerRadio의 라벨 텍스트를 해당 줄 수로 제한(line-clamp)하고,
+   * 넘치는 텍스트는 말줄임(…)으로 처리합니다.
+   * 너비가 제약되는 `fullWidth` 모드에서 가장 잘 동작합니다.
+   */
+  buttonLineClamp?: number;
 }
+
+/**
+ * 너비 설정 방식 (둘 중 하나만 사용):
+ * - `fullWidth: true` → Wrapper가 부모 가용 너비를 100% 채우고, 각 아이템을 동일 비율(`flex: 1`)로 분배합니다. 이때 `fixedWidth`는 생략 가능합니다.
+ * - `fullWidth` 미지정(또는 false) → 각 아이템의 고정 너비인 `fixedWidth`(px)가 필수입니다.
+ */
+export type ToggleButtonWidthProps =
+  | {
+      /** 부모 가용 너비를 100% 채우고 각 아이템을 동일 비율(flex:1)로 분배합니다. */
+      fullWidth: true;
+      /** fullWidth가 true이면 무시되며 생략 가능합니다. */
+      fixedWidth?: number;
+    }
+  | {
+      /** fixedWidth 기반 고정 너비 모드입니다. */
+      fullWidth?: false;
+      /** 각 아이템의 고정 너비(px)입니다. */
+      fixedWidth: number;
+    };
+
+export type ToggleButtonProps = ToggleButtonBaseProps & ToggleButtonWidthProps;
 
 export interface ToggleButtonOptionProps {}
 

--- a/packages/base/src/components/ToggleButton/useToggleButton.ts
+++ b/packages/base/src/components/ToggleButton/useToggleButton.ts
@@ -2,7 +2,9 @@ import { createContext, useContext, type ChangeEventHandler } from 'react';
 import type { ToggleButtonSizeVariantType } from './ToggleButton.types';
 
 export type ToggleButtonContextType = {
-  fixedWidth: number;
+  fixedWidth?: number;
+  fullWidth?: boolean;
+  buttonLineClamp?: number;
   targetName: string;
   sizeVar: ToggleButtonSizeVariantType;
   disabled: boolean;


### PR DESCRIPTION
…이즈 수정

ToggleButton
- fullWidth: Wrapper 너비 100% + 각 InnerRadio flex:1 균등 분배
- fullWidth 사용 시 fixedWidth 선택 / 미사용 시 필수 (discriminated union으로 타입 강제)
- buttonLineClamp: InnerRadio 라벨을 지정 줄 수로 제한 + 말줄임(…) 처리

Button
- XS에서 24px 고정 스피너가 텍스트(16px)보다 커 버튼이 32px로 부풀던 문제 수정
- LoadingSpinner에 size prop 추가, XS는 16px로 텍스트 줄높이에 맞춤

## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->


<!-- 관련있는 이슈 번호(#000)를 PR 제목에 적어주세요. -->

<!-- ex) [SF-1234] 무슨 기능 업데이트 -->

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
