### PR TITLE
feat(skills): Cursor 설치를 네이티브 Agent Skills로 전환

### DIFF
--- a/.changeset/skills-cursor-native.md
+++ b/.changeset/skills-cursor-native.md
@@ -2,6 +2,9 @@
 "@shoplflow/skills": minor
 ---
 
-feat(skills): Cursor 설치를 네이티브 Agent Skills(`.cursor/skills/<name>/SKILL.md`)로 전환
+feat(skills): Cursor 네이티브 Agent Skills 전환 + 자동 마이그레이션 + 버전 체크 스킬
 
-Cursor가 SKILL.md 표준을 네이티브 지원함에 따라, 기존 `.cursor/rules/*.mdc` 변환 대신 SKILL.md를 그대로 `.cursor/skills/`에 설치한다(글로벌 `~/.cursor/skills/` 포함). 구버전 Cursor 호환을 위해 `--legacy-cursor-rules` 플래그를 추가해 기존 `.cursor/rules/*.mdc` 방식도 선택 가능.
+- **Cursor 네이티브 설치**: `.cursor/rules/*.mdc` 변환 대신 SKILL.md를 그대로 `.cursor/skills/<name>/SKILL.md`에 설치(글로벌 `~/.cursor/skills/` 포함). 구버전 호환용 `--legacy-cursor-rules` 플래그 추가.
+- **레거시 자동 정리**: 네이티브 재설치 시 이전 버전이 만든 `.cursor/rules/shoplflow-*.mdc`(우리 슬러그만)를 자동 제거해 중복 방지.
+- **버전 스탬프**: 설치 위치에 `shoplflow-skills.lock.json`(Codex는 AGENTS.md 블록)으로 설치 버전 기록.
+- **신규 스킬 `shoplflow-skills-update`**: 기록된 버전을 `npm view @shoplflow/skills version`과 비교해 최신 여부 확인·업데이트 안내.

--- a/.changeset/skills-cursor-native.md
+++ b/.changeset/skills-cursor-native.md
@@ -1,0 +1,7 @@
+---
+"@shoplflow/skills": minor
+---
+
+feat(skills): Cursor 설치를 네이티브 Agent Skills(`.cursor/skills/<name>/SKILL.md`)로 전환
+
+Cursor가 SKILL.md 표준을 네이티브 지원함에 따라, 기존 `.cursor/rules/*.mdc` 변환 대신 SKILL.md를 그대로 `.cursor/skills/`에 설치한다(글로벌 `~/.cursor/skills/` 포함). 구버전 Cursor 호환을 위해 `--legacy-cursor-rules` 플래그를 추가해 기존 `.cursor/rules/*.mdc` 방식도 선택 가능.

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -13,7 +13,7 @@ Works with **Claude Code**, **OpenAI Codex**, and **Cursor** — the installer w
 | `shoplflow-theming` | `colorTokens`/`spacingTokens`/`typographyTokens`…; token KEY vs VALUE; `getDomain()` |
 | `shoplflow-icons-utils` | `@shoplflow/shopl-assets` / `hada-assets` icons + `@shoplflow/utils` hooks |
 
-The source of truth is `skills/<name>/SKILL.md` (Claude SKILL.md format). The installer transforms these for the other agents.
+The source of truth is `skills/<name>/SKILL.md` (the SKILL.md open standard). Claude Code and Cursor read this format natively, so the files are copied verbatim; for Codex the installer wires them into `AGENTS.md`.
 
 ## Install
 
@@ -33,7 +33,7 @@ npx @shoplflow/skills --agent all                  # claude + codex + cursor
 npx @shoplflow/skills --list                       # preview the skills
 ```
 
-Flags: `--agent claude|codex|cursor|all` · `--scope project|global` · `--dir <path>` · `--yes` · `--list`
+Flags: `--agent claude|codex|cursor|all` · `--scope project|global` · `--dir <path>` · `--legacy-cursor-rules` · `--yes` · `--list`
 
 > Prefer not to use `npx`? Copy this package folder and run `node install.mjs` with the same flags.
 
@@ -42,17 +42,17 @@ Flags: `--agent claude|codex|cursor|all` · `--scope project|global` · `--dir <
 | Agent | Project scope | Global scope |
 |-------|---------------|--------------|
 | **Claude Code** | `./.claude/skills/<name>/SKILL.md` | `~/.claude/skills/<name>/SKILL.md` |
-| **Cursor** | `./.cursor/rules/<name>.mdc` | `~/.cursor/rules/<name>.mdc` |
+| **Cursor** | `./.cursor/skills/<name>/SKILL.md` | `~/.cursor/skills/<name>/SKILL.md` |
 | **Codex** | `./AGENTS.md` (managed block) + `./.codex/skills/shoplflow/*.md` | `~/.codex/AGENTS.md` + `~/.codex/skills/shoplflow/*.md` |
 
 - **Claude**: skills are auto-discovered; the agent loads one when a task matches its description.
-- **Cursor**: rules are written as *Agent Requested* (`alwaysApply: false`) — Cursor pulls them in by description. Project scope (`.cursor/rules`) is the reliable path.
+- **Cursor**: installed as native [Agent Skills](https://cursor.com/docs/skills) under `.cursor/skills/` (the same SKILL.md standard as Claude) — Cursor loads them by description on relevant tasks. Pass `--legacy-cursor-rules` to instead emit `.cursor/rules/*.mdc` (*Agent Requested* rules) for Cursor versions predating Agent Skills.
 - **Codex**: `AGENTS.md` gets a managed block (between `<!-- shoplflow-skills:start -->` / `:end -->`) pointing at the skill files, so Codex reads the right guide on demand. Re-running replaces the block in place — safe and idempotent; your other `AGENTS.md` content is preserved.
 
 ## Updating / uninstalling
 
-- **Update**: re-run the installer. Claude/Cursor files are overwritten; the Codex `AGENTS.md` block is replaced in place.
-- **Uninstall**: delete the `<name>` skill folders / `.mdc` files, and for Codex remove the managed block from `AGENTS.md` plus `.codex/skills/shoplflow/`.
+- **Update**: re-run the installer. Claude/Cursor skill folders are overwritten; the Codex `AGENTS.md` block is replaced in place.
+- **Uninstall**: delete the `<name>` skill folders under `.claude/skills/` / `.cursor/skills/` (or the `.cursor/rules/*.mdc` files if you used `--legacy-cursor-rules`), and for Codex remove the managed block from `AGENTS.md` plus `.codex/skills/shoplflow/`.
 
 ## Notes
 

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -12,6 +12,7 @@ Works with **Claude Code**, **OpenAI Codex**, and **Cursor** — the installer w
 | `shoplflow-components` | `Button`, `Text`, `Stack`, `Icon`, overlays; `styleVar`/`sizeVar`; polymorphic `as` |
 | `shoplflow-theming` | `colorTokens`/`spacingTokens`/`typographyTokens`…; token KEY vs VALUE; `getDomain()` |
 | `shoplflow-icons-utils` | `@shoplflow/shopl-assets` / `hada-assets` icons + `@shoplflow/utils` hooks |
+| `shoplflow-skills-update` | Check whether the installed skills are the latest version and update them |
 
 The source of truth is `skills/<name>/SKILL.md` (the SKILL.md open standard). Claude Code and Cursor read this format natively, so the files are copied verbatim; for Codex the installer wires them into `AGENTS.md`.
 
@@ -51,7 +52,7 @@ Flags: `--agent claude|codex|cursor|all` · `--scope project|global` · `--dir <
 
 ## Updating / uninstalling
 
-- **Update**: re-run the installer. Claude/Cursor skill folders are overwritten; the Codex `AGENTS.md` block is replaced in place.
+- **Update**: re-run `npx @shoplflow/skills@latest --agent <…>` (pin `@latest` to skip the npx cache). Files are overwritten in place, the installer records the version in `shoplflow-skills.lock.json`, and for Cursor it auto-removes superseded `.cursor/rules/*.mdc` from pre-`0.2.0` installs. The bundled `shoplflow-skills-update` skill lets your agent compare that lock against `npm view @shoplflow/skills version` and update when behind. Skills are vendored, so they never auto-update — re-run to refresh.
 - **Uninstall**: delete the `<name>` skill folders under `.claude/skills/` / `.cursor/skills/` (or the `.cursor/rules/*.mdc` files if you used `--legacy-cursor-rules`), and for Codex remove the managed block from `AGENTS.md` plus `.codex/skills/shoplflow/`.
 
 ## Notes

--- a/packages/skills/install.mjs
+++ b/packages/skills/install.mjs
@@ -15,7 +15,7 @@
 // Flags: --agent claude|codex|cursor|all  --scope project|global  --dir <path>  --legacy-cursor-rules  --yes  --list  --help
 // No dependencies. Requires Node >= 16.
 
-import { readFile, writeFile, mkdir, readdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, readdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -27,6 +27,10 @@ const SKILLS_DIR = path.join(HERE, "skills");
 const AGENTS = ["claude", "codex", "cursor"];
 const MARK_START = "<!-- shoplflow-skills:start -->";
 const MARK_END = "<!-- shoplflow-skills:end -->";
+const LOCK_FILE = "shoplflow-skills.lock.json";
+const VERSION = JSON.parse(
+  await readFile(path.join(HERE, "package.json"), "utf8"),
+).version;
 
 // ---------- args ----------
 function parseArgs(argv) {
@@ -104,6 +108,25 @@ function basePath(scope, dir) {
   return scope === "global" ? os.homedir() : path.resolve(dir || process.cwd());
 }
 
+// Records the installed version so the shoplflow-skills-update skill can compare
+// it against `npm view @shoplflow/skills version`. Written next to the skills;
+// agents scan for SKILL.md folders and ignore this JSON file.
+async function stampVersion(rootDir, written) {
+  await mkdir(rootDir, { recursive: true });
+  const out = path.join(rootDir, LOCK_FILE);
+  const body = JSON.stringify(
+    {
+      name: "@shoplflow/skills",
+      version: VERSION,
+      installedAt: new Date().toISOString(),
+    },
+    null,
+    2,
+  );
+  await writeFile(out, body + "\n", "utf8");
+  written.push(out);
+}
+
 async function installClaude(skills, scope, dir, written) {
   const root = path.join(basePath(scope, dir), ".claude", "skills");
   for (const s of skills) {
@@ -112,13 +135,15 @@ async function installClaude(skills, scope, dir, written) {
     await writeFile(out, s.raw, "utf8");
     written.push(out);
   }
+  await stampVersion(root, written);
 }
 
 async function installCursor(skills, scope, dir, written, legacyRules) {
+  const base = basePath(scope, dir);
   if (legacyRules) {
     // Legacy: convert each skill to a Cursor MDC rule (.cursor/rules/<name>.mdc)
     // for Cursor versions predating native Agent Skills support.
-    const root = path.join(basePath(scope, dir), ".cursor", "rules");
+    const root = path.join(base, ".cursor", "rules");
     await mkdir(root, { recursive: true });
     for (const s of skills) {
       const out = path.join(root, `${s.slug}.mdc`);
@@ -126,17 +151,39 @@ async function installCursor(skills, scope, dir, written, legacyRules) {
       await writeFile(out, mdc, "utf8");
       written.push(out);
     }
+    await stampVersion(root, written);
     return;
   }
   // Native Cursor Agent Skills: .cursor/skills/<name>/SKILL.md.
   // Cursor reads the same SKILL.md standard as Claude Code, so we copy verbatim
   // (the `name:` frontmatter already matches the folder name, as Cursor requires).
-  const root = path.join(basePath(scope, dir), ".cursor", "skills");
+  const root = path.join(base, ".cursor", "skills");
   for (const s of skills) {
     const out = path.join(root, s.slug, "SKILL.md");
     await mkdir(path.dirname(out), { recursive: true });
     await writeFile(out, s.raw, "utf8");
     written.push(out);
+  }
+  await stampVersion(root, written);
+
+  // Migrate: an older installer wrote these skills as .cursor/rules/<slug>.mdc.
+  // Remove only our own slugs (and our stale lock) so re-running doesn't duplicate.
+  const legacyDir = path.join(base, ".cursor", "rules");
+  const migrated = [];
+  for (const s of skills) {
+    const legacy = path.join(legacyDir, `${s.slug}.mdc`);
+    if (existsSync(legacy)) {
+      await rm(legacy);
+      migrated.push(legacy);
+    }
+  }
+  const legacyLock = path.join(legacyDir, LOCK_FILE);
+  if (existsSync(legacyLock)) await rm(legacyLock);
+  if (migrated.length) {
+    console.log(
+      `\nCursor: migrated ${migrated.length} legacy rule(s) from .cursor/rules/ to .cursor/skills/ (old files removed):`,
+    );
+    for (const m of migrated) console.log(`  - ${m}`);
   }
 }
 
@@ -168,6 +215,8 @@ async function installCodex(skills, scope, dir, written) {
   const block = [
     MARK_START,
     "## @shoplflow design system",
+    "",
+    `> Installed @shoplflow/skills version: ${VERSION}`,
     "",
     "When the task involves `@shoplflow/*` packages (base components, design tokens, theming, icons, utils hooks), read the relevant guide below before answering:",
     "",

--- a/packages/skills/install.mjs
+++ b/packages/skills/install.mjs
@@ -2,7 +2,7 @@
 // Installer for the @shoplflow agent skills.
 // Installs the bundled skills into the format used by your AI coding agent:
 //   - Claude Code -> <base>/.claude/skills/<name>/SKILL.md
-//   - Cursor      -> <base>/.cursor/rules/<name>.mdc
+//   - Cursor      -> <base>/.cursor/skills/<name>/SKILL.md (native Agent Skills; --legacy-cursor-rules for .cursor/rules/*.mdc)
 //   - Codex       -> <base>/.codex/skills/shoplflow/<name>.md + managed block in AGENTS.md
 //
 // Usage:
@@ -12,7 +12,7 @@
 //   node install.mjs --agent cursor --dir /path/to/app
 //   node install.mjs --list                # list bundled skills
 //
-// Flags: --agent claude|codex|cursor|all  --scope project|global  --dir <path>  --yes  --list  --help
+// Flags: --agent claude|codex|cursor|all  --scope project|global  --dir <path>  --legacy-cursor-rules  --yes  --list  --help
 // No dependencies. Requires Node >= 16.
 
 import { readFile, writeFile, mkdir, readdir } from "node:fs/promises";
@@ -34,6 +34,7 @@ function parseArgs(argv) {
     agent: null,
     scope: null,
     dir: null,
+    legacyCursorRules: false,
     yes: false,
     list: false,
     help: false,
@@ -44,6 +45,7 @@ function parseArgs(argv) {
     if (a === "--help" || a === "-h") out.help = true;
     else if (a === "--list") out.list = true;
     else if (a === "--yes" || a === "-y") out.yes = true;
+    else if (a === "--legacy-cursor-rules") out.legacyCursorRules = true;
     else if (a.startsWith("--agent"))
       out.agent = a.includes("=") ? a.split("=")[1] : next();
     else if (a.startsWith("--scope"))
@@ -112,13 +114,28 @@ async function installClaude(skills, scope, dir, written) {
   }
 }
 
-async function installCursor(skills, scope, dir, written) {
-  const root = path.join(basePath(scope, dir), ".cursor", "rules");
-  await mkdir(root, { recursive: true });
+async function installCursor(skills, scope, dir, written, legacyRules) {
+  if (legacyRules) {
+    // Legacy: convert each skill to a Cursor MDC rule (.cursor/rules/<name>.mdc)
+    // for Cursor versions predating native Agent Skills support.
+    const root = path.join(basePath(scope, dir), ".cursor", "rules");
+    await mkdir(root, { recursive: true });
+    for (const s of skills) {
+      const out = path.join(root, `${s.slug}.mdc`);
+      const mdc = `---\ndescription: ${s.description}\nglobs:\nalwaysApply: false\n---\n\n${s.body}\n`;
+      await writeFile(out, mdc, "utf8");
+      written.push(out);
+    }
+    return;
+  }
+  // Native Cursor Agent Skills: .cursor/skills/<name>/SKILL.md.
+  // Cursor reads the same SKILL.md standard as Claude Code, so we copy verbatim
+  // (the `name:` frontmatter already matches the folder name, as Cursor requires).
+  const root = path.join(basePath(scope, dir), ".cursor", "skills");
   for (const s of skills) {
-    const out = path.join(root, `${s.slug}.mdc`);
-    const mdc = `---\ndescription: ${s.description}\nglobs:\nalwaysApply: false\n---\n\n${s.body}\n`;
-    await writeFile(out, mdc, "utf8");
+    const out = path.join(root, s.slug, "SKILL.md");
+    await mkdir(path.dirname(out), { recursive: true });
+    await writeFile(out, s.raw, "utf8");
     written.push(out);
   }
 }
@@ -198,7 +215,7 @@ async function interactive(args, skills) {
       console.log("\nWhich agent CLI do you use?");
       console.log("  1) claude   (Claude Code  -> .claude/skills/)");
       console.log("  2) codex    (OpenAI Codex -> AGENTS.md + .codex/skills/)");
-      console.log("  3) cursor   (Cursor       -> .cursor/rules/)");
+      console.log("  3) cursor   (Cursor       -> .cursor/skills/)");
       console.log("  4) all");
       const pick = await ask(rl, "Select [1-4]: ");
       agent =
@@ -242,6 +259,7 @@ Flags:
   --agent claude|codex|cursor|all
   --scope project|global        (default: project)
   --dir <path>                  (project scope target; default: cwd)
+  --legacy-cursor-rules         Cursor: write .cursor/rules/*.mdc instead of .cursor/skills/
   --yes, -y                     skip confirmation
   --list                        list bundled skills and exit`);
     return;
@@ -292,7 +310,8 @@ Flags:
   }
 
   const written = [];
-  for (const t of targets) await INSTALLERS[t](skills, scope, dir, written);
+  for (const t of targets)
+    await INSTALLERS[t](skills, scope, dir, written, args.legacyCursorRules);
 
   console.log(
     `\n✓ Installed ${skills.length} skills for ${targets.join(", ")} (${scope}). Files written:`,
@@ -305,7 +324,9 @@ Flags:
   }
   if (targets.includes("cursor")) {
     console.log(
-      '\nCursor: rules are "Agent Requested" (alwaysApply: false) — the agent pulls them in by description. Project-scope (.cursor/rules) is the reliable path.',
+      args.legacyCursorRules
+        ? "\nCursor (legacy): wrote .cursor/rules/*.mdc as Agent-Requested rules."
+        : "\nCursor: installed native Agent Skills under .cursor/skills/ (SKILL.md standard). Cursor loads them by description on relevant tasks.",
     );
   }
 }

--- a/packages/skills/skills/shoplflow-skills-update/SKILL.md
+++ b/packages/skills/skills/shoplflow-skills-update/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: shoplflow-skills-update
+description: Check whether the installed @shoplflow agent skills are the latest version and update them if outdated. Use when the user asks if the @shoplflow skills are current/up to date/stale, mentions updating or upgrading the shoplflow skills, or before relying on these skills after a long gap.
+---
+
+# Updating the @shoplflow skills
+
+The @shoplflow skills are **vendored** — copied into this project by `npx @shoplflow/skills`. They do **not** auto-update when a new `@shoplflow/skills` is published, so check periodically.
+
+## 1. Read the installed version
+Look for `shoplflow-skills.lock.json` next to the installed skills:
+- Claude Code → `.claude/skills/shoplflow-skills.lock.json`
+- Cursor → `.cursor/skills/shoplflow-skills.lock.json`
+- Codex → the `Installed @shoplflow/skills version:` line in the `@shoplflow design system` block of `AGENTS.md`
+
+Its `version` is what's installed. **If the file/line is missing**, the install predates version stamping (≤ 0.1.0) — treat as outdated.
+
+## 2. Get the latest published version
+```bash
+npm view @shoplflow/skills version
+```
+
+## 3. Compare
+- Installed `version` **equals** latest → up to date, nothing to do.
+- Installed `version` **lower** (or unknown) → outdated, update below.
+
+## 4. Update if outdated
+Re-run the installer for whichever agent(s) this project uses, pinning `@latest` to bypass the npx cache:
+```bash
+npx @shoplflow/skills@latest --agent <claude|codex|cursor|all>
+```
+Re-running overwrites the skill files in place, refreshes `shoplflow-skills.lock.json`, and (for Cursor) auto-removes superseded `.cursor/rules/*.mdc` from older installs.
+
+## Notes
+- This only refreshes the **skill docs** — it does not change your app's `@shoplflow/*` runtime package versions (bump those in `package.json` separately).
+- Commit the refreshed skill files + lock so your whole team gets the update.
+- The lock file is ignored by Claude/Cursor skill discovery (they look for `<name>/SKILL.md`), so it's safe to keep checked in.


### PR DESCRIPTION
## 배경
Cursor가 이제 **Agent Skills를 네이티브 지원**합니다 ([Cursor Docs](https://cursor.com/docs/skills)) — `.cursor/skills/<name>/SKILL.md` 표준을 Claude Code와 동일하게 읽습니다. 기존 인스톨러는 SKILL.md를 `.cursor/rules/*.mdc`로 **변환**해 넣고 있어 권장 방식과 어긋났습니다.

## 변경
- `installCursor`: 기본 동작을 **`.cursor/skills/<name>/SKILL.md` 에 SKILL.md 그대로 복사**로 변경 (변환 제거, Claude 핸들러와 동일). 글로벌 `~/.cursor/skills/` 지원.
- `--legacy-cursor-rules` 플래그 추가 → 구버전 Cursor용 `.cursor/rules/*.mdc` 방식 유지.
- 헤더 주석 / `--help` / 인터랙티브 메뉴 / 완료 메시지 / `README.md` 갱신.

## 호환성
- `name:` frontmatter가 폴더명과 일치하여 Cursor 요구사항 충족.
- 구버전 Cursor 사용자는 `--legacy-cursor-rules`로 기존 동작 그대로 사용 가능.

## 테스트
- `--agent cursor` → `.cursor/skills/{setup,components,theming,icons-utils}/SKILL.md` 생성 확인
- `--agent cursor --legacy-cursor-rules` → `.cursor/rules/*.mdc` 생성 확인
- `--list` / 파싱 / `changeset status`(minor) 정상

## 릴리즈
- changeset `minor` → `@shoplflow/skills` `0.1.0` → `0.2.0`
- ⚠️ Trusted Publishing 미등록 시 0.2.0 CI 자동배포가 실패하므로 수동 publish 또는 사전 등록 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)