### PR TITLE
feat(skills): shoplflow를 Claude/Cursor/Codex 플러그인(skills + MCP)으로 배포

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "shoplflow-marketplace",
+  "interface": {
+    "displayName": "Shoplflow"
+  },
+  "plugins": [
+    {
+      "name": "shoplflow",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/shopl/shoplflow.git",
+        "path": "./packages/skills",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.changeset/skills-plugin-bundle.md
+++ b/.changeset/skills-plugin-bundle.md
@@ -1,0 +1,5 @@
+---
+"@shoplflow/skills": patch
+---
+
+Add plugin distribution alongside the npx installer. Consumers on Claude Code, Cursor, or Codex can now install the Shoplflow skills **and** the `@shoplflow/mcp` server in one step via a plugin (host marketplaces under `.claude-plugin/`, `.cursor-plugin/`, `.agents/plugins/`, all pointing at `packages/skills`). The `npx @shoplflow/skills` installer is unchanged and remains the skills-only fallback. README documents both paths.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "shoplflow-marketplace",
+  "owner": {
+    "name": "Shoplflow",
+    "url": "https://github.com/shopl/shoplflow"
+  },
+  "description": "Shoplflow design-system plugins: agent skills + MCP server for consumers of the @shoplflow/* packages.",
+  "plugins": [
+    {
+      "name": "shoplflow",
+      "source": "./packages/skills",
+      "description": "Shoplflow design-system agent skills + MCP server for developers consuming the @shoplflow/* packages."
+    }
+  ]
+}

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "shoplflow-marketplace",
+  "owner": {
+    "name": "Shoplflow",
+    "url": "https://github.com/shopl/shoplflow"
+  },
+  "plugins": [
+    {
+      "name": "shoplflow",
+      "source": "packages/skills",
+      "description": "Shoplflow design-system agent skills + MCP server for developers consuming the @shoplflow/* packages."
+    }
+  ]
+}

--- a/packages/skills/.claude-plugin/plugin.json
+++ b/packages/skills/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "shoplflow",
+  "version": "0.1.0",
+  "description": "Shoplflow design-system agent skills + MCP server for developers consuming the @shoplflow/* packages.",
+  "author": { "name": "Shoplflow" },
+  "homepage": "https://github.com/shopl/shoplflow/tree/main/packages/skills",
+  "repository": "https://github.com/shopl/shoplflow",
+  "license": "Apache-2.0",
+  "keywords": [
+    "design-system",
+    "shoplflow",
+    "react",
+    "components",
+    "design-tokens"
+  ],
+  "skills": "./skills/",
+  "mcpServers": {
+    "shoplflow": {
+      "command": "npx",
+      "args": ["-y", "@shoplflow/mcp"]
+    }
+  }
+}

--- a/packages/skills/.codex-plugin/plugin.json
+++ b/packages/skills/.codex-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "shoplflow",
+  "version": "0.1.0",
+  "description": "Shoplflow design-system agent skills + MCP server for developers consuming the @shoplflow/* packages.",
+  "author": {
+    "name": "Shoplflow",
+    "url": "https://github.com/shopl/shoplflow"
+  },
+  "homepage": "https://github.com/shopl/shoplflow/tree/main/packages/skills",
+  "repository": "https://github.com/shopl/shoplflow",
+  "license": "Apache-2.0",
+  "keywords": [
+    "design-system",
+    "shoplflow",
+    "react",
+    "components",
+    "design-tokens"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}

--- a/packages/skills/.cursor-plugin/plugin.json
+++ b/packages/skills/.cursor-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "shoplflow",
+  "version": "0.1.0",
+  "description": "Shoplflow design-system agent skills + MCP server for developers consuming the @shoplflow/* packages.",
+  "author": { "name": "Shoplflow" },
+  "homepage": "https://github.com/shopl/shoplflow/tree/main/packages/skills",
+  "repository": "https://github.com/shopl/shoplflow",
+  "license": "Apache-2.0",
+  "keywords": [
+    "design-system",
+    "shoplflow",
+    "react",
+    "components",
+    "design-tokens"
+  ],
+  "skills": "./skills/",
+  "mcpServers": {
+    "shoplflow": {
+      "command": "npx",
+      "args": ["-y", "@shoplflow/mcp"],
+      "env": {}
+    }
+  }
+}

--- a/packages/skills/.mcp.json
+++ b/packages/skills/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "shoplflow": {
+      "command": "npx",
+      "args": ["-y", "@shoplflow/mcp"],
+      "env": {}
+    }
+  }
+}

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -1,22 +1,59 @@
-# @shoplflow agent skills
+# @shoplflow agent skills + plugin
 
-Downloadable **AI-agent skills** for developers who consume the `@shoplflow/*` packages in their own apps. They teach an AI coding assistant how to install, theme, and use the Shoplflow design system correctly — accurate import paths, the `styleVar`/`sizeVar` patterns, design tokens, brand theming, icons, and utils hooks.
+Downloadable AI-agent **skills** — plus an optional bundled **MCP server** — for developers who consume the `@shoplflow/*` packages in their own apps. They teach an AI coding assistant how to install, theme, and use the Shoplflow design system correctly — accurate import paths, the `styleVar`/`sizeVar` patterns, design tokens, brand theming, icons, and utils hooks.
 
-Works with **Claude Code**, **OpenAI Codex**, and **Cursor** — the installer writes each skill in the format that agent expects.
+Works with **Claude Code**, **OpenAI Codex**, and **Cursor**.
 
 ## What's inside
 
-| Skill | Covers |
-|-------|--------|
-| `shoplflow-setup` | Install, peer deps, required global CSS, `ShoplflowProvider`, SHOPL/HADA domain |
-| `shoplflow-components` | `Button`, `Text`, `Stack`, `Icon`, overlays; `styleVar`/`sizeVar`; polymorphic `as` |
-| `shoplflow-theming` | `colorTokens`/`spacingTokens`/`typographyTokens`…; token KEY vs VALUE; `getDomain()` |
-| `shoplflow-icons-utils` | `@shoplflow/shopl-assets` / `hada-assets` icons + `@shoplflow/utils` hooks |
-| `shoplflow-skills-update` | Check whether the installed skills are the latest version and update them |
+| Skill                     | Covers                                                                               |
+| ------------------------- | ------------------------------------------------------------------------------------ |
+| `shoplflow-setup`         | Install, peer deps, required global CSS, `ShoplflowProvider`, SHOPL/HADA domain      |
+| `shoplflow-components`    | `Button`, `Text`, `Stack`, `Icon`, overlays; `styleVar`/`sizeVar`; polymorphic `as`  |
+| `shoplflow-theming`       | `colorTokens`/`spacingTokens`/`typographyTokens`…; token KEY vs VALUE; `getDomain()` |
+| `shoplflow-icons-utils`   | `@shoplflow/shopl-assets` / `hada-assets` icons + `@shoplflow/utils` hooks           |
+| `shoplflow-skills-update` | Check whether the installed skills are the latest version and update them            |
 
-The source of truth is `skills/<name>/SKILL.md` (the SKILL.md open standard). Claude Code and Cursor read this format natively, so the files are copied verbatim; for Codex the installer wires them into `AGENTS.md`.
+The source of truth is `skills/<name>/SKILL.md` (the SKILL.md open standard). Claude Code, Cursor, and Codex all read this format, so the same files back both install paths below.
 
-## Install
+## Two ways to install
+
+Pick **one**:
+
+- **A — As a plugin (recommended):** installs the skills **and** wires up the `@shoplflow/mcp` server in a single step, and your agent keeps both up to date through its own plugin-update flow. Needs a plugin-capable agent version (Claude Code, Cursor, or Codex).
+- **B — Skills only via `npx`:** the original installer. Vendors just the skill files into your repo (no MCP). Use it if you don't want the MCP server, or your agent predates plugin support.
+
+Both paths ship the **same** `skills/` files — A additionally configures MCP.
+
+---
+
+### A. As a plugin — skills + MCP in one step
+
+The plugin pulls the skills from this repo and declares the MCP server as `npx -y @shoplflow/mcp`, so you never hand-edit an MCP config. Updating the plugin (via your agent) refreshes both the skills and the MCP wiring.
+
+**Claude Code**
+
+```bash
+/plugin marketplace add shopl/shoplflow
+/plugin install shoplflow@shoplflow-marketplace
+```
+
+**Cursor**
+Open **Customize** → add a team marketplace pointing at the `shopl/shoplflow` GitHub repo (Cursor reads `.cursor-plugin/marketplace.json` at the repo root), then install the **shoplflow** plugin (project or user scope).
+
+**Codex**
+
+```bash
+codex plugin marketplace add shopl/shoplflow
+```
+
+then install the **shoplflow** plugin from the Codex plugin directory.
+
+> Where the manifests live (for maintainers): each host's plugin manifest is under `packages/skills/.{claude,cursor,codex}-plugin/`, and the marketplace catalogs are at the repo root (`.claude-plugin/`, `.cursor-plugin/`, `.agents/plugins/`). All three point at the same `packages/skills/skills/` folder and the same `@shoplflow/mcp` command.
+
+---
+
+### B. Skills only via `npx` (no MCP)
 
 From the root of the project you want to add the skills to, run:
 
@@ -38,25 +75,26 @@ Flags: `--agent claude|codex|cursor|all` · `--scope project|global` · `--dir <
 
 > Prefer not to use `npx`? Copy this package folder and run `node install.mjs` with the same flags.
 
-### Where files land
+#### Where files land
 
-| Agent | Project scope | Global scope |
-|-------|---------------|--------------|
-| **Claude Code** | `./.claude/skills/<name>/SKILL.md` | `~/.claude/skills/<name>/SKILL.md` |
-| **Cursor** | `./.cursor/skills/<name>/SKILL.md` | `~/.cursor/skills/<name>/SKILL.md` |
-| **Codex** | `./AGENTS.md` (managed block) + `./.codex/skills/shoplflow/*.md` | `~/.codex/AGENTS.md` + `~/.codex/skills/shoplflow/*.md` |
+| Agent           | Project scope                                                    | Global scope                                            |
+| --------------- | ---------------------------------------------------------------- | ------------------------------------------------------- |
+| **Claude Code** | `./.claude/skills/<name>/SKILL.md`                               | `~/.claude/skills/<name>/SKILL.md`                      |
+| **Cursor**      | `./.cursor/skills/<name>/SKILL.md`                               | `~/.cursor/skills/<name>/SKILL.md`                      |
+| **Codex**       | `./AGENTS.md` (managed block) + `./.codex/skills/shoplflow/*.md` | `~/.codex/AGENTS.md` + `~/.codex/skills/shoplflow/*.md` |
 
 - **Claude**: skills are auto-discovered; the agent loads one when a task matches its description.
-- **Cursor**: installed as native [Agent Skills](https://cursor.com/docs/skills) under `.cursor/skills/` (the same SKILL.md standard as Claude) — Cursor loads them by description on relevant tasks. Pass `--legacy-cursor-rules` to instead emit `.cursor/rules/*.mdc` (*Agent Requested* rules) for Cursor versions predating Agent Skills.
+- **Cursor**: installed as native [Agent Skills](https://cursor.com/docs/skills) under `.cursor/skills/` (the same SKILL.md standard as Claude) — Cursor loads them by description on relevant tasks. Pass `--legacy-cursor-rules` to instead emit `.cursor/rules/*.mdc` (_Agent Requested_ rules) for Cursor versions predating Agent Skills.
 - **Codex**: `AGENTS.md` gets a managed block (between `<!-- shoplflow-skills:start -->` / `:end -->`) pointing at the skill files, so Codex reads the right guide on demand. Re-running replaces the block in place — safe and idempotent; your other `AGENTS.md` content is preserved.
 
 ## Updating / uninstalling
 
-- **Update**: re-run `npx @shoplflow/skills@latest --agent <…>` (pin `@latest` to skip the npx cache). Files are overwritten in place, the installer records the version in `shoplflow-skills.lock.json`, and for Cursor it auto-removes superseded `.cursor/rules/*.mdc` from pre-`0.2.0` installs. The bundled `shoplflow-skills-update` skill lets your agent compare that lock against `npm view @shoplflow/skills version` and update when behind. Skills are vendored, so they never auto-update — re-run to refresh.
-- **Uninstall**: delete the `<name>` skill folders under `.claude/skills/` / `.cursor/skills/` (or the `.cursor/rules/*.mdc` files if you used `--legacy-cursor-rules`), and for Codex remove the managed block from `AGENTS.md` plus `.codex/skills/shoplflow/`.
+- **Plugin (path A)**: update through your agent's marketplace/plugin update flow (e.g. Claude Code `/plugin marketplace update`), which re-pulls the latest skills and MCP wiring from this repo. Uninstall by removing the plugin in your agent.
+- **npx (path B)**: re-run `npx @shoplflow/skills@latest --agent <…>` (pin `@latest` to skip the npx cache). Files are overwritten in place, the installer records the version in `shoplflow-skills.lock.json`, and for Cursor it auto-removes superseded `.cursor/rules/*.mdc` from pre-`0.2.0` installs. The bundled `shoplflow-skills-update` skill lets your agent compare that lock against `npm view @shoplflow/skills version` and update when behind. npx skills are vendored, so they never auto-update — re-run to refresh.
+- **Uninstall (npx)**: delete the `<name>` skill folders under `.claude/skills/` / `.cursor/skills/` (or the `.cursor/rules/*.mdc` files if you used `--legacy-cursor-rules`), and for Codex remove the managed block from `AGENTS.md` plus `.codex/skills/shoplflow/`.
 
 ## Notes
 
 - Skills are **self-contained** — they reference only the published npm package API (`@shoplflow/base`, `@shoplflow/utils`, `@shoplflow/shopl-assets`, `@shoplflow/hada-assets`), no monorepo internals — so they work in any consumer project.
-- The installer has **no dependencies** and needs Node ≥ 16.
+- The `npx` installer has **no dependencies** and needs Node ≥ 16.
 - Verified against: `@shoplflow/base@0.48.0`, `@shoplflow/utils@0.8.0`, `@shoplflow/shopl-assets@0.12.44`, `@shoplflow/hada-assets@0.1.10`.


### PR DESCRIPTION
## 무엇을 / 왜

`@shoplflow/*` 패키지를 소비하는 개발자가 **skills + `@shoplflow/mcp` 서버를 한 번에** 설치할 수 있도록, shoplflow를 세 호스트(Claude Code · Cursor · Codex)의 **플러그인**으로 묶었습니다.

세 호스트 모두 2026년에 "skills + MCP를 하나의 설치 단위로 묶는" plugin 시스템을 갖췄기에, 같은 `skills/` 콘텐츠를 그대로 재사용해 호스트별 manifest만 추가했습니다. 기존 `npx @shoplflow/skills` 설치기는 **그대로 유지**되어 skills-only fallback 역할을 합니다(순수 추가 변경).

## 구조

```
packages/skills/                 ← 플러그인 루트 (기존 skills/ 재사용)
├── .claude-plugin/plugin.json   mcpServers 인라인
├── .cursor-plugin/plugin.json   mcpServers 인라인
├── .codex-plugin/plugin.json    mcpServers → "./.mcp.json"
└── .mcp.json                    Codex용 (camelCase mcpServers 키)

(레포 루트) 마켓플레이스 카탈로그
├── .claude-plugin/marketplace.json   source: "./packages/skills"
├── .cursor-plugin/marketplace.json   source: "packages/skills"
└── .agents/plugins/marketplace.json  source: git-subdir → packages/skills
```

- 세 manifest 모두 **같은 `skills/` 폴더 + `npx -y @shoplflow/mcp`** 를 가리킴 (콘텐츠 중복 없음)
- 마켓플레이스 `name` = `shoplflow-marketplace`, 플러그인 `name` = `shoplflow` (Claude `plugin@marketplace` 설치 시 모호성 방지로 다르게 둠)
- 플러그인 manifest는 npm tarball(`files: install.mjs, skills, README.md`)에 **미포함** → git 마켓플레이스로만 소비. 그래서 플러그인 버전(`0.1.0`)은 npm `@shoplflow/skills`(0.2.x 라인)와 **독립**으로 관리.

## 소비자 설치

| 호스트 | 설치 |
|--------|------|
| **Claude Code** | `/plugin marketplace add shopl/shoplflow` → `/plugin install shoplflow@shoplflow-marketplace` |
| **Codex** | `codex plugin marketplace add shopl/shoplflow` → 디렉터리에서 `shoplflow` 설치 |
| **Cursor** | Customize → `shopl/shoplflow` 팀 마켓플레이스 추가 → `shoplflow` 설치 |

## 검증

- 7개 JSON 전부 파싱 OK, prettier 통과, pre-commit type-check 통과
- 호스트별 plugin·marketplace **스키마는 각 사 공식 문서(1차 출처)로 확인**
- Codex `.mcp.json`은 공식 예시의 `mcp_servers`(snake_case) 대신 **`mcpServers`(camelCase)** 사용 — codex 이슈 #22105(snake_case 미로딩) 회피

## 주의 / 한계

- 세 마켓플레이스가 **이 레포의 GitHub를 ref로 참조**하므로, `marketplace add`가 동작하려면 본 PR이 `main`(또는 참조 ref)에 머지돼 있어야 함.
- Cursor `/add-plugin` CLI와 Codex `codex plugin install <name>`의 **정확한 호출**은 공식 문서에서 확정하지 못해, README는 UI/디렉터리 안내로 작성. 스키마 자체는 확인됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)