### PR TITLE
feat: TypeScript 6.0.3 마이그레이션 및 단일 버전 고정

### DIFF
--- a/.changeset/typescript-6-migration.md
+++ b/.changeset/typescript-6-migration.md
@@ -1,0 +1,16 @@
+---
+"@shoplflow/base": patch
+"@shoplflow/templates": patch
+"@shoplflow/utils": patch
+"@shoplflow/shopl-assets": patch
+"@shoplflow/hada-assets": patch
+"@shoplflow/mcp": patch
+---
+
+chore: TypeScript 6 (6.0.3) 마이그레이션 및 단일 버전 고정
+
+- 워크스페이스 전 패키지의 TypeScript 를 `6.0.3` 으로 통일 (pnpm-workspace.yaml `catalog:` 로 단일 소스 관리, `pnpm.overrides` 로 transitive 의존성까지 강제)
+- TS 7 제거 예정 옵션 정리: `baseUrl` 제거, `moduleResolution: node → bundler` (utils·shopl-assets 는 `module` 도 `esnext` 로 조정). 배포 번들 포맷(CJS/ESM)은 tsup 이 결정하므로 변화 없음
+- `target: es5` 는 배포물의 ES5 다운레벨(구형 브라우저 지원) 유지를 위해 존치하고, 이 옵션만 `ignoreDeprecations: "6.0"` 로 억제
+- CSS side-effect import 대응 `*.css` 모듈 선언 추가 (base·templates)
+- 소스/공개 API 변경 없음 (빌드 툴체인 변경)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint-staged": "13.2.3",
     "prettier": "^3.0.0",
     "turbo": "^2.8.10",
-    "typescript": "^5.9.0",
+    "typescript": "catalog:",
     "typescript-eslint": "^8.18.0",
     "vitest": "^1.2.2"
   },
@@ -58,9 +58,11 @@
   },
   "packageManager": "pnpm@10.29.3",
   "pnpm": {
+    "comment:typescript-override": "TypeScript 6 마이그레이션: 이 override 로 transitive 의존성(@figma/code-connect, commitlint 등)까지 catalog 의 단일 TS 버전으로 강제한다. 버전은 pnpm-workspace.yaml 의 catalog 한 곳에서만 관리.",
     "overrides": {
       "playwright-core": "1.58.2",
-      "playwright": "1.58.2"
+      "playwright": "1.58.2",
+      "typescript": "catalog:"
     }
   },
   "dependencies": {

--- a/packages/base/images.d.ts
+++ b/packages/base/images.d.ts
@@ -2,3 +2,7 @@ declare module '*.png';
 declare module '*.jpg';
 declare module '*.jpeg';
 declare module '*.svg';
+// TypeScript 6 마이그레이션: TS 6부터 side-effect import(`import '...css'`)에 대해
+// 모듈 선언을 찾지 못하면 에러(TS2882)가 발생한다. react-datepicker 등의 CSS를
+// 부수효과로 import 하므로 아래 선언이 필요하다. (제거 시 DayDatepicker 등에서 타입체크 실패)
+declare module '*.css';

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -107,7 +107,7 @@
     "jsdom": "^24.0.0",
     "tslib": "^2.6.2",
     "tsup": "7.2.0",
-    "typescript": "^5.9.0"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@figma/code-connect": "^1.4.3",

--- a/packages/base/tsconfig.json
+++ b/packages/base/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    // TS6: baseUrl 제거 (paths 미사용 · non-relative import 없음)
     "module": "esnext",
     "target": "es6",
     "allowJs": false,

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -48,7 +48,7 @@
     "ts-jest": "29.0.2",
     "ts-loader": "9.4.2",
     "tslib": "^2.6.2",
-    "typescript": "^5.9.0",
+    "typescript": "catalog:",
     "vite": "3.2.7",
     "ws": "8.13.0"
   },

--- a/packages/hada-assets/package.json
+++ b/packages/hada-assets/package.json
@@ -63,7 +63,7 @@
     "react-dom": "^18",
     "ts-node": "^10.9.1",
     "tsup": "7.2.0",
-    "typescript": "^5.9.0"
+    "typescript": "catalog:"
   },
   "repository": {
     "type": "git",

--- a/packages/hada-assets/tsconfig.json
+++ b/packages/hada-assets/tsconfig.json
@@ -9,10 +9,10 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    // TS6: node(node10) → bundler 로 현대화, baseUrl 제거(paths 미사용)
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": false,
-    "baseUrl": ".",
     "noFallthroughCasesInSwitch": true,
     "jsxImportSource": "@emotion/react",
     "declaration": true,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^22.0.0",
     "ts-morph": "^24.0.0",
     "tsup": "7.2.0",
-    "typescript": "^5.9.0"
+    "typescript": "catalog:"
   },
   "repository": {
     "type": "git",

--- a/packages/shopl-assets/package.json
+++ b/packages/shopl-assets/package.json
@@ -63,7 +63,7 @@
     "react-dom": "^18",
     "ts-node": "^10.9.1",
     "tsup": "7.2.0",
-    "typescript": "^5.9.0"
+    "typescript": "catalog:"
   },
   "repository": {
     "type": "git",

--- a/packages/shopl-assets/tsconfig.json
+++ b/packages/shopl-assets/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
-    "module": "commonjs",
+    // TS6: baseUrl 제거. moduleResolution 을 bundler 로 올리며 module 도 esnext 로 변경(bundler 는 commonjs 와 병행 불가).
+    // 출력 포맷(CJS/ESM)은 tsup 이 결정하므로 배포 번들에는 영향 없음.
+    "module": "esnext",
     "allowJs": false,
     "skipLibCheck": true,
     "noImplicitAny": false,
@@ -12,7 +13,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "declaration": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/packages/templates/images.d.ts
+++ b/packages/templates/images.d.ts
@@ -2,3 +2,6 @@ declare module '*.png';
 declare module '*.jpg';
 declare module '*.jpeg';
 declare module '*.svg';
+// TypeScript 6 마이그레이션: templates 는 base 의 소스(../base/src)를 함께 타입체크하므로
+// base 의 side-effect CSS import(TS2882)를 여기서도 해소해야 한다. base/images.d.ts 와 동일하게 유지.
+declare module '*.css';

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -75,7 +75,7 @@
     "ts-node": "^10.9.1",
     "tslib": "^2.6.2",
     "tsup": "7.2.0",
-    "typescript": "^5.9.0"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/packages/templates/tsconfig.json
+++ b/packages/templates/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
+    // TS6: baseUrl 제거 (paths 미사용 · non-relative import 없음)
     "module": "esnext",
     "target": "es6",
     "allowJs": false,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -57,7 +57,7 @@
     "react": "^18.2.0",
     "ts-node": "^10.9.1",
     "tsup": "7.2.0",
-    "typescript": "^5.9.0"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "lodash-es": "^4.17.21"

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
-    "module": "commonjs",
+    // TS6: baseUrl 제거. moduleResolution 을 bundler 로 올리며 module 도 esnext 로 변경(bundler 는 commonjs 와 병행 불가).
+    // 출력 포맷(CJS/ESM)은 tsup 이 결정하므로 배포 번들에는 영향 없음.
+    "module": "esnext",
     "allowJs": false,
     "skipLibCheck": true,
     "noImplicitAny": false,
@@ -12,7 +13,7 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "declaration": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   playwright-core: 1.58.2
   playwright: 1.58.2
+  typescript: 6.0.3
 
 importers:
 
@@ -39,7 +40,7 @@ importers:
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import-x:
         specifier: ^4.6.0
-        version: 4.16.2(@typescript-eslint/utils@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1))
+        version: 4.16.2(@typescript-eslint/utils@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-prettier:
         specifier: ^5.2.0
         version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.1)
@@ -51,10 +52,10 @@ importers:
         version: 5.2.0(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-storybook:
         specifier: ^0.11.0
-        version: 0.11.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 0.11.6(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       eslint-plugin-unused-imports:
         specifier: ^4.1.0
-        version: 4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
+        version: 4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))
       globals:
         specifier: ^15.14.0
         version: 15.15.0
@@ -74,11 +75,11 @@ importers:
         specifier: ^2.8.10
         version: 2.8.10
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       typescript-eslint:
         specifier: ^8.18.0
-        version: 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       vitest:
         specifier: ^1.2.2
         version: 1.6.1(@types/node@22.19.15)(jsdom@24.1.3)(sass@1.62.1)(terser@5.46.0)
@@ -169,25 +170,25 @@ importers:
         version: 10.2.8(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/addon-designs':
         specifier: ^11.1.1
-        version: 11.1.2(@storybook/addon-docs@10.2.8(@types/react@18.2.29)(esbuild@0.21.5)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.21.5)))(@types/react@18.2.29)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 11.1.2(@storybook/addon-docs@10.2.8(@types/react@18.2.29)(esbuild@0.18.17)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.18.17)))(@types/react@18.2.29)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/addon-docs':
         specifier: ^10.2.4
-        version: 10.2.8(@types/react@18.2.29)(esbuild@0.21.5)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.21.5))
+        version: 10.2.8(@types/react@18.2.29)(esbuild@0.18.17)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.18.17))
       '@storybook/addon-links':
         specifier: ^10.2.1
         version: 10.2.8(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/addon-mcp':
         specifier: ^0.2.2
-        version: 0.2.2(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)
+        version: 0.2.2(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)
       '@storybook/addon-themes':
         specifier: ^10.2.8
         version: 10.2.8(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/react-vite':
         specifier: ^10.2.1
-        version: 10.2.8(esbuild@0.21.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.21.5))
+        version: 10.2.8(esbuild@0.18.17)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.18.17))
       '@storybook/test-runner':
         specifier: ^0.24.2
-        version: 0.24.3(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))
+        version: 0.24.3(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))
       '@testing-library/jest-dom':
         specifier: ^6.1.5
         version: 6.9.1
@@ -229,16 +230,16 @@ importers:
         version: 10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3)
       tslib:
         specifier: ^2.6.2
         version: 2.8.1
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^1.2.2
         version: 1.6.1(@types/node@20.4.9)(jsdom@24.1.3)(sass@1.62.1)(terser@5.46.0)
@@ -278,19 +279,19 @@ importers:
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.2.29)(react@18.2.0))(@types/react@18.2.29)(react@18.2.0)
       '@rollup/plugin-typescript':
         specifier: ^8.5.0
-        version: 8.5.0(rollup@2.79.1)(tslib@2.8.1)(typescript@5.9.3)
+        version: 8.5.0(rollup@2.79.1)(tslib@2.8.1)(typescript@6.0.3)
       '@testing-library/react':
         specifier: 13.4.0
         version: 13.4.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@twind/core':
         specifier: ^1.1.3
-        version: 1.1.3(typescript@5.9.3)
+        version: 1.1.3(typescript@6.0.3)
       '@twind/preset-autoprefix':
         specifier: ^1.0.7
-        version: 1.0.7(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)
+        version: 1.0.7(@twind/core@1.1.3(typescript@6.0.3))(typescript@6.0.3)
       '@twind/preset-tailwind':
         specifier: ^1.1.4
-        version: 1.1.4(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)
+        version: 1.1.4(@twind/core@1.1.3(typescript@6.0.3))(typescript@6.0.3)
       '@types/chrome':
         specifier: 0.0.224
         version: 0.0.224
@@ -335,16 +336,16 @@ importers:
         version: 1.62.1
       ts-jest:
         specifier: 29.0.2
-        version: 29.0.2(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.18.17)(jest@30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.0.2(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.18.17)(jest@30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3)))(typescript@6.0.3)
       ts-loader:
         specifier: 9.4.2
-        version: 9.4.2(typescript@5.9.3)(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.18.17))
+        version: 9.4.2(typescript@6.0.3)(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.18.17))
       tslib:
         specifier: ^2.6.2
         version: 2.8.1
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
       vite:
         specifier: 3.2.7
         version: 3.2.7(@types/node@18.15.11)(sass@1.62.1)(terser@5.46.0)
@@ -371,7 +372,7 @@ importers:
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.2.29)(react@18.2.0))(@types/react@18.2.29)(react@18.2.0)
       '@svgr/cli':
         specifier: 8.1.0
-        version: 8.1.0(typescript@5.9.3)
+        version: 8.1.0(typescript@6.0.3)
       '@types/node':
         specifier: 20.4.9
         version: 20.4.9
@@ -392,13 +393,13 @@ importers:
         version: 18.2.0(react@18.2.0)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/mcp:
     dependencies:
@@ -426,10 +427,10 @@ importers:
         version: 24.0.0
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@22.19.15)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@22.19.15)(typescript@6.0.3))(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/shopl-assets:
     devDependencies:
@@ -450,7 +451,7 @@ importers:
         version: 11.14.1(@emotion/react@11.14.0(@types/react@18.2.29)(react@18.2.0))(@types/react@18.2.29)(react@18.2.0)
       '@svgr/cli':
         specifier: 8.1.0
-        version: 8.1.0(typescript@5.9.3)
+        version: 8.1.0(typescript@6.0.3)
       '@types/node':
         specifier: 20.4.9
         version: 20.4.9
@@ -471,13 +472,13 @@ importers:
         version: 18.2.0(react@18.2.0)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/skills: {}
 
@@ -576,22 +577,22 @@ importers:
         version: 10.2.8(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/addon-designs':
         specifier: ^11.1.1
-        version: 11.1.2(@storybook/addon-docs@10.2.8(@types/react@18.2.29)(esbuild@0.18.17)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.18.17)))(@types/react@18.2.29)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 11.1.2(@storybook/addon-docs@10.2.8(@types/react@18.2.29)(esbuild@0.21.5)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.21.5)))(@types/react@18.2.29)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/addon-docs':
         specifier: ^10.2.4
-        version: 10.2.8(@types/react@18.2.29)(esbuild@0.18.17)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.18.17))
+        version: 10.2.8(@types/react@18.2.29)(esbuild@0.21.5)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.21.5))
       '@storybook/addon-links':
         specifier: ^10.2.1
         version: 10.2.8(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/addon-mcp':
         specifier: ^0.2.2
-        version: 0.2.2(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)
+        version: 0.2.2(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)
       '@storybook/addon-themes':
         specifier: ^10.2.8
         version: 10.2.8(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/react-vite':
         specifier: ^10.2.1
-        version: 10.2.8(esbuild@0.18.17)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.18.17))
+        version: 10.2.8(esbuild@0.21.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.21.5))
       '@types/node':
         specifier: 20.4.9
         version: 20.4.9
@@ -612,16 +613,16 @@ importers:
         version: 6.1.3(@types/react@18.2.29)(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3)
       tslib:
         specifier: ^2.6.2
         version: 2.8.1
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   packages/utils:
     dependencies:
@@ -658,7 +659,7 @@ importers:
         version: 0.2.3(@babel/core@7.29.0)
       esbuild-plugin-d.ts:
         specifier: ^1.1.0
-        version: 1.3.1(typescript@5.9.3)
+        version: 1.3.1(typescript@6.0.3)
       jsdom:
         specifier: ^24.0.0
         version: 24.1.3
@@ -667,13 +668,13 @@ importers:
         version: 18.2.0
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)
+        version: 10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@6.0.3)
       tsup:
         specifier: 7.2.0
-        version: 7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3)
+        version: 7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@6.0.3))(typescript@6.0.3)
       typescript:
-        specifier: ^5.9.0
-        version: 5.9.3
+        specifier: 6.0.3
+        version: 6.0.3
 
   test-env:
     dependencies:
@@ -713,10 +714,10 @@ importers:
         version: 18.2.13
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.0.0
-        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: ^6.0.0
-        version: 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+        version: 6.21.0(eslint@8.57.1)(typescript@6.0.3)
       '@vitejs/plugin-react':
         specifier: ^4.0.3
         version: 4.7.0(vite@4.5.14(@types/node@22.19.15)(sass@1.62.1)(terser@5.46.0))
@@ -2228,7 +2229,7 @@ packages:
   '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4':
     resolution: {integrity: sha512-6PyZBYKnnVNqOSB0YFly+62R7dmov8segT27A+RVTBVd4iAE6kbW9QBJGlyR2yG4D4ohzhZSTIu7BK1UTtmFFA==}
     peerDependencies:
-      typescript: '>= 4.3.x'
+      typescript: 6.0.3
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
       typescript:
@@ -2350,7 +2351,7 @@ packages:
     peerDependencies:
       rollup: ^2.14.0
       tslib: '*'
-      typescript: '>=3.7.0'
+      typescript: 6.0.3
     peerDependenciesMeta:
       tslib:
         optional: true
@@ -2636,7 +2637,7 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       storybook: ^10.2.8
-      typescript: '>= 4.9.x'
+      typescript: 6.0.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -2919,7 +2920,7 @@ packages:
     resolution: {integrity: sha512-/B/aNFerMb2IeyjSJy3SJxqVxhrT77gBDknLMiZqXIRr4vNJqiuhx7KqUSRzDCwUmyGuogkamz+aOLzN6MeSLw==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
-      typescript: ^4.8.4
+      typescript: 6.0.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -2929,7 +2930,7 @@ packages:
     engines: {node: '>=14.15.0'}
     peerDependencies:
       '@twind/core': ^1.1.0
-      typescript: ^4.8.4
+      typescript: 6.0.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -2939,7 +2940,7 @@ packages:
     engines: {node: '>=14.15.0'}
     peerDependencies:
       '@twind/core': ^1.1.0
-      typescript: ^4.8.4
+      typescript: 6.0.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -3120,7 +3121,7 @@ packages:
     peerDependencies:
       '@typescript-eslint/parser': ^8.58.1
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/parser@6.21.0':
     resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
@@ -3137,19 +3138,19 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/project-service@8.57.1':
     resolution: {integrity: sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/project-service@8.58.1':
     resolution: {integrity: sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/scope-manager@6.21.0':
     resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
@@ -3167,13 +3168,13 @@ packages:
     resolution: {integrity: sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/tsconfig-utils@8.58.1':
     resolution: {integrity: sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/type-utils@6.21.0':
     resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
@@ -3190,7 +3191,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/types@6.21.0':
     resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
@@ -3217,13 +3218,13 @@ packages:
     resolution: {integrity: sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/typescript-estree@8.58.1':
     resolution: {integrity: sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/utils@6.21.0':
     resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
@@ -3236,14 +3237,14 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.0.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/utils@8.58.1':
     resolution: {integrity: sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
   '@typescript-eslint/visitor-keys@6.21.0':
     resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
@@ -4207,7 +4208,7 @@ packages:
       '@types/node': '*'
       cosmiconfig: '>=7'
       ts-node: '>=10'
-      typescript: '>=4'
+      typescript: 6.0.3
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -4217,7 +4218,7 @@ packages:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
     peerDependencies:
-      typescript: '>=4.9.5'
+      typescript: 6.0.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4719,7 +4720,7 @@ packages:
     resolution: {integrity: sha512-is6W2FalyN5CFMMSNB6k6wIxTw5MGakQVN8+aCnF1g5mwQ21c/IkjgEkwlZy8GyLErmrTY1xympl+HPHtJw8DQ==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      typescript: '*'
+      typescript: 6.0.3
 
   esbuild-sunos-64@0.15.18:
     resolution: {integrity: sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==}
@@ -7024,7 +7025,7 @@ packages:
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
     peerDependencies:
-      typescript: '>= 4.3.x'
+      typescript: 6.0.3
 
   react-docgen@8.0.2:
     resolution: {integrity: sha512-+NRMYs2DyTP4/tqWz371Oo50JqmWltR1h2gcdgUMAWZJIAvrd0/SqlCfx7tpzpl/s36rzw6qH2MjoNrxtRNYhA==}
@@ -7807,19 +7808,19 @@ packages:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
     engines: {node: '>=16'}
     peerDependencies:
-      typescript: '>=4.2.0'
+      typescript: 6.0.3
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
     peerDependencies:
-      typescript: '>=4.8.4'
+      typescript: 6.0.3
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
-      typescript: '>=4.8.4'
+      typescript: 6.0.3
 
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -7838,7 +7839,7 @@ packages:
       babel-jest: ^29.0.0
       esbuild: '*'
       jest: ^29.0.0
-      typescript: '>=4.3'
+      typescript: 6.0.3
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -7853,7 +7854,7 @@ packages:
     resolution: {integrity: sha512-OmlC4WVmFv5I0PpaxYb+qGeGOdm5giHU7HwDDUjw59emP2UYMHy9fFSDcYgSNoH8sXcj4hGCSEhlDZ9ULeDraA==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      typescript: '*'
+      typescript: 6.0.3
       webpack: ^5.0.0
 
   ts-morph@24.0.0:
@@ -7869,7 +7870,7 @@ packages:
       '@swc/core': '>=1.2.50'
       '@swc/wasm': '>=1.2.50'
       '@types/node': '*'
-      typescript: '>=2.7'
+      typescript: 6.0.3
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -7890,7 +7891,7 @@ packages:
     peerDependencies:
       '@swc/core': ^1
       postcss: ^8.4.12
-      typescript: '>=4.1.0'
+      typescript: 6.0.3
     peerDependenciesMeta:
       '@swc/core':
         optional: true
@@ -8005,10 +8006,10 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
+      typescript: 6.0.3
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -8129,7 +8130,7 @@ packages:
   valibot@1.2.0:
     resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
     peerDependencies:
-      typescript: '>=5'
+      typescript: 6.0.3
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -9570,14 +9571,14 @@ snapshots:
       '@commitlint/types': 17.8.1
       '@types/node': 20.5.1
       chalk: 4.1.2
-      cosmiconfig: 8.3.6(typescript@5.9.3)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.9.3))(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3))(typescript@5.9.3)
+      cosmiconfig: 8.3.6(typescript@6.0.3)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@6.0.3))(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3))(typescript@6.0.3)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
       resolve-from: 5.0.0
-      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@18.15.11)(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@18.15.11)(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -10057,7 +10058,7 @@ snapshots:
       prompts: 2.4.2
       strip-ansi: 6.0.1
       ts-morph: 27.0.2
-      typescript: 5.9.3
+      typescript: 6.0.3
       undici: 7.24.7
       zod: 3.25.58
       zod-validation-error: 3.5.4(zod@3.25.58)
@@ -10194,7 +10195,7 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))':
+  '@jest/core@30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.3.0
       '@jest/pattern': 30.0.1
@@ -10209,7 +10210,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -10229,7 +10230,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.3.0(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3))':
+  '@jest/core@30.3.0(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.3.0
       '@jest/pattern': 30.0.1
@@ -10244,7 +10245,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -10435,13 +10436,13 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@5.9.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(typescript@6.0.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))':
     dependencies:
       glob: 13.0.3
-      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      react-docgen-typescript: 2.4.0(typescript@6.0.3)
       vite: 5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -10617,12 +10618,12 @@ snapshots:
     optionalDependencies:
       rollup: 4.57.1
 
-  '@rollup/plugin-typescript@8.5.0(rollup@2.79.1)(tslib@2.8.1)(typescript@5.9.3)':
+  '@rollup/plugin-typescript@8.5.0(rollup@2.79.1)(tslib@2.8.1)(typescript@6.0.3)':
     dependencies:
       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
       resolve: 1.22.11
       rollup: 2.79.1
-      typescript: 5.9.3
+      typescript: 6.0.3
     optionalDependencies:
       tslib: 2.8.1
 
@@ -10807,15 +10808,15 @@ snapshots:
     optionalDependencies:
       react: 18.2.0
 
-  '@storybook/addon-mcp@0.2.2(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)':
+  '@storybook/addon-mcp@0.2.2(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)':
     dependencies:
-      '@storybook/mcp': 0.2.1(typescript@5.9.3)
-      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.2(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
-      '@tmcp/transport-http': 0.8.4(tmcp@1.19.2(typescript@5.9.3))
+      '@storybook/mcp': 0.2.1(typescript@6.0.3)
+      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.2(typescript@6.0.3))(valibot@1.2.0(typescript@6.0.3))
+      '@tmcp/transport-http': 0.8.4(tmcp@1.19.2(typescript@6.0.3))
       picoquery: 2.5.0
       storybook: 10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      tmcp: 1.19.2(typescript@5.9.3)
-      valibot: 1.2.0(typescript@5.9.3)
+      tmcp: 1.19.2(typescript@6.0.3)
+      valibot: 1.2.0(typescript@6.0.3)
     transitivePeerDependencies:
       - '@tmcp/auth'
       - typescript
@@ -10878,12 +10879,12 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@storybook/mcp@0.2.1(typescript@5.9.3)':
+  '@storybook/mcp@0.2.1(typescript@6.0.3)':
     dependencies:
-      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.2(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
-      '@tmcp/transport-http': 0.8.4(tmcp@1.19.2(typescript@5.9.3))
-      tmcp: 1.19.2(typescript@5.9.3)
-      valibot: 1.2.0(typescript@5.9.3)
+      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.2(typescript@6.0.3))(valibot@1.2.0(typescript@6.0.3))
+      '@tmcp/transport-http': 0.8.4(tmcp@1.19.2(typescript@6.0.3))
+      tmcp: 1.19.2(typescript@6.0.3)
+      valibot: 1.2.0(typescript@6.0.3)
     transitivePeerDependencies:
       - '@tmcp/auth'
       - typescript
@@ -10894,12 +10895,12 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       storybook: 10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@storybook/react-vite@10.2.8(esbuild@0.18.17)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.18.17))':
+  '@storybook/react-vite@10.2.8(esbuild@0.18.17)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.18.17))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@6.0.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
       '@storybook/builder-vite': 10.2.8(esbuild@0.18.17)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.18.17))
-      '@storybook/react': 10.2.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)
+      '@storybook/react': 10.2.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 18.2.0
@@ -10916,12 +10917,12 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react-vite@10.2.8(esbuild@0.21.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.21.5))':
+  '@storybook/react-vite@10.2.8(esbuild@0.21.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.21.5))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@5.9.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(typescript@6.0.3)(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
       '@storybook/builder-vite': 10.2.8(esbuild@0.21.5)(rollup@4.57.1)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.4.21(@types/node@20.4.9)(sass@1.62.1)(terser@5.46.0))(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.21.5))
-      '@storybook/react': 10.2.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)
+      '@storybook/react': 10.2.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)
       empathic: 2.0.0
       magic-string: 0.30.21
       react: 18.2.0
@@ -10938,7 +10939,7 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.2.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)':
+  '@storybook/react@10.2.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@6.0.3)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/react-dom-shim': 10.2.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
@@ -10947,11 +10948,11 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       storybook: 10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/test-runner@0.24.3(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))':
+  '@storybook/test-runner@0.24.3(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(storybook@10.2.8(@testing-library/dom@9.3.4)(prettier@3.8.1)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -10961,14 +10962,14 @@ snapshots:
       '@swc/core': 1.15.11
       '@swc/jest': 0.2.39(@swc/core@1.15.11)
       expect-playwright: 0.8.0
-      jest: 30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))
       jest-circus: 30.3.0(babel-plugin-macros@3.1.0)
       jest-environment-node: 30.3.0
       jest-junit: 16.0.0
       jest-process-manager: 0.4.0
       jest-runner: 30.3.0
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 3.0.1(jest@30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3)))
+      jest-watch-typeahead: 3.0.1(jest@30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3)))
       nyc: 15.1.0
       playwright: 1.58.2
       playwright-core: 1.58.2
@@ -11029,12 +11030,12 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.29.0)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.29.0)
 
-  '@svgr/cli@8.1.0(typescript@5.9.3)':
+  '@svgr/cli@8.1.0(typescript@6.0.3)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.9.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
-      '@svgr/plugin-prettier': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
+      '@svgr/core': 8.1.0(typescript@6.0.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
+      '@svgr/plugin-prettier': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)
       camelcase: 6.3.0
       chalk: 4.1.2
       commander: 9.5.0
@@ -11045,12 +11046,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/core@8.1.0(typescript@5.9.3)':
+  '@svgr/core@8.1.0(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.29.0
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.9.3)
+      cosmiconfig: 8.3.6(typescript@6.0.3)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -11061,26 +11062,26 @@ snapshots:
       '@babel/types': 7.29.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@svgr/babel-preset': 8.1.0(@babel/core@7.29.0)
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-prettier@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))':
+  '@svgr/plugin-prettier@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.9.3)
+      '@svgr/core': 8.1.0(typescript@6.0.3)
       deepmerge: 4.3.1
       prettier: 2.8.8
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.9.3)
-      cosmiconfig: 8.3.6(typescript@5.9.3)
+      '@svgr/core': 8.1.0(typescript@6.0.3)
+      cosmiconfig: 8.3.6(typescript@6.0.3)
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
@@ -11216,22 +11217,22 @@ snapshots:
     dependencies:
       '@testing-library/dom': 9.3.4
 
-  '@tmcp/adapter-valibot@0.1.5(tmcp@1.19.2(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))':
+  '@tmcp/adapter-valibot@0.1.5(tmcp@1.19.2(typescript@6.0.3))(valibot@1.2.0(typescript@6.0.3))':
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@valibot/to-json-schema': 1.5.0(valibot@1.2.0(typescript@5.9.3))
-      tmcp: 1.19.2(typescript@5.9.3)
-      valibot: 1.2.0(typescript@5.9.3)
+      '@valibot/to-json-schema': 1.5.0(valibot@1.2.0(typescript@6.0.3))
+      tmcp: 1.19.2(typescript@6.0.3)
+      valibot: 1.2.0(typescript@6.0.3)
 
-  '@tmcp/session-manager@0.2.1(tmcp@1.19.2(typescript@5.9.3))':
+  '@tmcp/session-manager@0.2.1(tmcp@1.19.2(typescript@6.0.3))':
     dependencies:
-      tmcp: 1.19.2(typescript@5.9.3)
+      tmcp: 1.19.2(typescript@6.0.3)
 
-  '@tmcp/transport-http@0.8.4(tmcp@1.19.2(typescript@5.9.3))':
+  '@tmcp/transport-http@0.8.4(tmcp@1.19.2(typescript@6.0.3))':
     dependencies:
-      '@tmcp/session-manager': 0.2.1(tmcp@1.19.2(typescript@5.9.3))
+      '@tmcp/session-manager': 0.2.1(tmcp@1.19.2(typescript@6.0.3))
       esm-env: 1.2.2
-      tmcp: 1.19.2(typescript@5.9.3)
+      tmcp: 1.19.2(typescript@6.0.3)
 
   '@trysound/sax@0.2.0': {}
 
@@ -11255,24 +11256,24 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@twind/core@1.1.3(typescript@5.9.3)':
+  '@twind/core@1.1.3(typescript@6.0.3)':
     dependencies:
       csstype: 3.2.3
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@twind/preset-autoprefix@1.0.7(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)':
+  '@twind/preset-autoprefix@1.0.7(@twind/core@1.1.3(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@twind/core': 1.1.3(typescript@5.9.3)
+      '@twind/core': 1.1.3(typescript@6.0.3)
       style-vendorizer: 2.2.3
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@twind/preset-tailwind@1.1.4(@twind/core@1.1.3(typescript@5.9.3))(typescript@5.9.3)':
+  '@twind/preset-tailwind@1.1.4(@twind/core@1.1.3(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
-      '@twind/core': 1.1.3(typescript@5.9.3)
+      '@twind/core': 1.1.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -11443,13 +11444,13 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.3
       eslint: 8.57.1
@@ -11457,68 +11458,68 @@ snapshots:
       ignore: 5.3.2
       natural-compare: 1.4.0
       semver: 7.7.4
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.58.1
-      '@typescript-eslint/type-utils': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.58.1
       eslint: 9.39.4(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.4.3
       eslint: 8.57.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.58.1
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.57.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.57.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.57.1
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.58.1(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.58.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.58.1
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11537,35 +11538,35 @@ snapshots:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/visitor-keys': 8.58.1
 
-  '@typescript-eslint/tsconfig-utils@8.57.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.57.1(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/tsconfig-utils@8.58.1(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.58.1(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@6.0.3)
       debug: 4.4.3
       eslint: 8.57.1
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.6.1)
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11575,7 +11576,7 @@ snapshots:
 
   '@typescript-eslint/types@8.58.1': {}
 
-  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
@@ -11584,75 +11585,75 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.7.4
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.57.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.57.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.57.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.57.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.57.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.57.1
       '@typescript-eslint/visitor-keys': 8.57.1
       debug: 4.4.3
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.4.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.4.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.58.1(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.58.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.58.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@6.0.3)
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/visitor-keys': 8.58.1
       debug: 4.4.3
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
-      ts-api-utils: 2.5.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.7.1
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@6.0.3)
       eslint: 8.57.1
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.57.1
       '@typescript-eslint/types': 8.57.1
-      '@typescript-eslint/typescript-estree': 8.57.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.57.1(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -11732,9 +11733,9 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@5.9.3))':
+  '@valibot/to-json-schema@1.5.0(valibot@1.2.0(typescript@6.0.3))':
     dependencies:
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.2.0(typescript@6.0.3)
 
   '@vitejs/plugin-react-swc@3.11.0(vite@4.5.14(@types/node@22.19.15)(sass@1.62.1)(terser@5.46.0))':
     dependencies:
@@ -12688,12 +12689,12 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.9.3))(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3))(typescript@5.9.3):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@6.0.3))(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
       '@types/node': 20.5.1
-      cosmiconfig: 8.3.6(typescript@5.9.3)
-      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@18.15.11)(typescript@5.9.3)
-      typescript: 5.9.3
+      cosmiconfig: 8.3.6(typescript@6.0.3)
+      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@18.15.11)(typescript@6.0.3)
+      typescript: 6.0.3
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -12703,14 +12704,14 @@ snapshots:
       path-type: 4.0.0
       yaml: 1.10.2
 
-  cosmiconfig@8.3.6(typescript@5.9.3):
+  cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   create-require@1.1.1: {}
 
@@ -12990,7 +12991,7 @@ snapshots:
 
   dts-bundle-generator@9.5.1:
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
       yargs: 17.7.2
 
   dunder-proto@1.0.1:
@@ -13222,13 +13223,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
 
-  esbuild-plugin-d.ts@1.3.1(typescript@5.9.3):
+  esbuild-plugin-d.ts@1.3.1(typescript@6.0.3):
     dependencies:
       chalk: 4.1.2
       dts-bundle-generator: 9.5.1
       lodash.merge: 4.6.2
       type-fest: 4.41.0
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   esbuild-sunos-64@0.15.18:
     optional: true
@@ -13348,7 +13349,7 @@ snapshots:
       - supports-color
     optional: true
 
-  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@package-json/types': 0.0.12
       '@typescript-eslint/types': 8.57.1
@@ -13362,7 +13363,7 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
@@ -13411,21 +13412,21 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-storybook@0.11.6(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  eslint-plugin-storybook@0.11.6(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3):
     dependencies:
       '@storybook/csf': 0.1.13
-      '@typescript-eslint/utils': 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.6.1)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-unused-imports@4.4.1(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -14551,15 +14552,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3)):
+  jest-cli@30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -14570,15 +14571,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3)):
+  jest-cli@30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))
+      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -14589,7 +14590,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -14616,12 +14617,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 18.15.11
-      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@18.15.11)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@18.15.11)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -14648,12 +14649,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.4.9
-      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@22.19.15)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -14680,12 +14681,12 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.15
-      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -14712,7 +14713,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.15
-      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@18.15.11)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@18.15.11)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -14969,11 +14970,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.3.0
 
-  jest-watch-typeahead@3.0.1(jest@30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))):
+  jest-watch-typeahead@3.0.1(jest@30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))):
     dependencies:
       ansi-escapes: 7.3.0
       chalk: 5.3.0
-      jest: 30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))
       jest-regex-util: 30.0.1
       jest-watcher: 30.3.0
       slash: 5.1.0
@@ -15013,12 +15014,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3)):
+  jest@30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3))
+      jest-cli: 30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -15026,12 +15027,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3)):
+  jest@30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))
+      '@jest/core': 30.3.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))
+      jest-cli: 30.3.0(@types/node@20.4.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -16172,29 +16173,29 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@6.0.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.2
     optionalDependencies:
       postcss: 8.5.6
-      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@6.0.3)
 
-  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.2
     optionalDependencies:
       postcss: 8.5.6
-      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3)
 
-  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@22.19.15)(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@22.19.15)(typescript@6.0.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.2
     optionalDependencies:
       postcss: 8.5.6
-      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@22.19.15)(typescript@5.9.3)
+      ts-node: 10.9.2(@swc/core@1.15.11)(@types/node@22.19.15)(typescript@6.0.3)
 
   postcss@8.5.6:
     dependencies:
@@ -16323,9 +16324,9 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  react-docgen-typescript@2.4.0(typescript@5.9.3):
+  react-docgen-typescript@2.4.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   react-docgen@8.0.2:
     dependencies:
@@ -17235,13 +17236,13 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  tmcp@1.19.2(typescript@5.9.3):
+  tmcp@1.19.2(typescript@6.0.3):
     dependencies:
       '@standard-schema/spec': 1.1.0
       json-rpc-2.0: 1.7.1
       sqids: 0.3.0
       uri-template-matcher: 1.1.2
-      valibot: 1.2.0(typescript@5.9.3)
+      valibot: 1.2.0(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
@@ -17288,33 +17289,33 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@1.4.3(typescript@5.9.3):
+  ts-api-utils@1.4.3(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  ts-api-utils@2.4.0(typescript@5.9.3):
+  ts-api-utils@2.4.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  ts-api-utils@2.5.0(typescript@5.9.3):
+  ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   ts-dedent@2.2.0: {}
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.0.2(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.18.17)(jest@30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.0.2(@babel/core@7.29.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.18.17)(jest@30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3)))(typescript@6.0.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@18.15.11)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.5.1)(typescript@6.0.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.7.4
-      typescript: 5.9.3
+      typescript: 6.0.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.29.0
@@ -17322,13 +17323,13 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.29.0)
       esbuild: 0.18.17
 
-  ts-loader@9.4.2(typescript@5.9.3)(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.18.17)):
+  ts-loader@9.4.2(typescript@6.0.3)(webpack@5.105.2(@swc/core@1.15.11)(esbuild@0.18.17)):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.19.0
       micromatch: 4.0.8
       semver: 7.7.4
-      typescript: 5.9.3
+      typescript: 6.0.3
       webpack: 5.105.2(@swc/core@1.15.11)(esbuild@0.18.17)
 
   ts-morph@24.0.0:
@@ -17341,7 +17342,7 @@ snapshots:
       '@ts-morph/common': 0.28.1
       code-block-writer: 13.0.3
 
-  ts-node@10.9.2(@swc/core@1.15.11)(@types/node@18.15.11)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.11)(@types/node@18.15.11)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -17355,13 +17356,13 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.11
 
-  ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -17375,13 +17376,13 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.11
 
-  ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -17395,13 +17396,13 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.11
 
-  ts-node@10.9.2(@swc/core@1.15.11)(@types/node@22.19.15)(typescript@5.9.3):
+  ts-node@10.9.2(@swc/core@1.15.11)(@types/node@22.19.15)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -17415,7 +17416,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.9.3
+      typescript: 6.0.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
@@ -17430,7 +17431,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@5.9.3))(typescript@5.9.3):
+  tsup@7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.18.17)
       cac: 6.7.14
@@ -17440,7 +17441,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@5.9.3))
+      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.33)(typescript@6.0.3))
       resolve-from: 5.0.0
       rollup: 3.29.5
       source-map: 0.8.0-beta.0
@@ -17449,12 +17450,12 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.11
       postcss: 8.5.6
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
 
-  tsup@7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))(typescript@5.9.3):
+  tsup@7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.18.17)
       cac: 6.7.14
@@ -17464,7 +17465,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@5.9.3))
+      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.4.9)(typescript@6.0.3))
       resolve-from: 5.0.0
       rollup: 3.29.5
       source-map: 0.8.0-beta.0
@@ -17473,12 +17474,12 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.11
       postcss: 8.5.6
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
 
-  tsup@7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@22.19.15)(typescript@5.9.3))(typescript@5.9.3):
+  tsup@7.2.0(@swc/core@1.15.11)(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@22.19.15)(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.18.17)
       cac: 6.7.14
@@ -17488,7 +17489,7 @@ snapshots:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@22.19.15)(typescript@5.9.3))
+      postcss-load-config: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@22.19.15)(typescript@6.0.3))
       resolve-from: 5.0.0
       rollup: 3.29.5
       source-map: 0.8.0-beta.0
@@ -17497,7 +17498,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.11
       postcss: 8.5.6
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -17596,18 +17597,18 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript-eslint@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3))(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.6.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   ufo@1.6.3: {}
 
@@ -17752,9 +17753,9 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  valibot@1.2.0(typescript@5.9.3):
+  valibot@1.2.0(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   validate-npm-package-license@3.0.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,10 @@ packages:
   - '!**/test/**'
   - test-env
 
+catalog:
+  # 워크스페이스 전체에서 단일 TypeScript 버전을 강제한다. 버전 변경은 이 항목만 수정.
+  typescript: 6.0.3
+
 ignoredBuiltDependencies:
   - '@swc/core'
   - core-js-pure

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,12 @@
     /* 기본 옵션
      * ------------------------------------------------------------------------------------------------------------------------------------------------ */
     // "incremental": true,                   /* 증분 컴파일 활성화 */
-    "baseUrl": ".",
+    // TypeScript 6 마이그레이션: baseUrl / moduleResolution=node10 은 TS 7 제거 대상이라 여기서 정리했다.
+    //  - baseUrl: 라이브러리 패키지는 paths 미사용 + non-relative import 도 없어 제거해도 안전.
+    //  - moduleResolution: 번들 라이브러리이므로 node → bundler 로 현대화.
+    // 남은 target=es5 는 배포 번들의 ES5 다운레벨(구형 브라우저 지원)에 영향을 주므로 의도적으로 유지하며,
+    // 이 옵션만 TS 6 deprecation 에러가 나기 때문에 ignoreDeprecations 로 억제한다. (ES5 지원 중단 시 함께 제거)
+    "ignoreDeprecations": "6.0",
     "target": "es5",
     /* ECMAScript 목표 버전 설정: 'ES3'(기본), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "esnext",
@@ -60,8 +65,8 @@
 
     /* 모듈 분석 옵션
      * ------------------------------------------------------------------------------------------------------------------------------------------------ */
-    "moduleResolution": "node",
-    /* 모듈 분석 방법 설정: 'node' (Node.js) 또는 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "bundler",
+    /* 모듈 분석 방법 설정: 번들러(tsup/esbuild)로 빌드하므로 'bundler'. (구 'node'=node10 은 TS 7 제거 대상) */
     // "baseUrl": "./",                       /* 절대 경로 모듈이 아닌, 모듈이 기본적으로 위치한 디렉토리 설정 (예: './modules-name') */
     // "paths": {},                           /* 'baseUrl'을 기준으로 상대 위치로 가져오기를 다시 매핑하는 항목 설정 */
     // "rootDirs": [],                        /* 런타임 시 프로젝트 구조를 나타내는 로트 디렉토리 목록 */


### PR DESCRIPTION
## 개요

프로젝트의 TypeScript 를 **6.0.3** 으로 마이그레이션하고, 워크스페이스 전체가 **항상 동일한 버전**을 사용하도록 고정합니다.

## 변경 사항

### 1. 버전 마이그레이션 + 단일 버전 고정
- TypeScript `5.9 → 6.0.3` (v6 라인 최신 안정판)
- `pnpm-workspace.yaml` **catalog** 에서 버전을 단일 소스로 관리 → 루트 + 7개 패키지 모두 `"catalog:"` 참조
- `pnpm.overrides` 로 transitive 의존성(`@figma/code-connect`, commitlint 등)까지 강제 → 락파일 내 컴파일러가 `6.0.3` **하나만** 존재

### 2. TS 6 대응
- side-effect CSS import(`import '...react-datepicker.css'`)에 대한 신규 에러 `TS2882` 해결 → `*.css` 모듈 선언 추가 (base·templates)

### 3. TS 7 제거 예정(deprecated) 옵션 정리
- `baseUrl` 제거 — 라이브러리 패키지는 `paths` 미사용 · non-relative import 없음 (실사용 0건)
- `moduleResolution: node(node10) → bundler` — utils·shopl-assets 는 `module` 도 `esnext` 로 동반 조정 (출력 포맷은 tsup 이 결정하므로 배포 번들 불변)
- `target: es5` **존치** — 배포물의 ES5 다운레벨(구형 브라우저 지원) 유지가 제품 결정이라, 이 옵션만 `ignoreDeprecations: "6.0"` 로 억제

> 변경 지점마다 변경 이유·주의사항을 한글 주석으로 기재했습니다.

## 검증

| 항목 | 결과 |
|------|------|
| `pnpm type-check` | ✅ 6/6 (deprecation 경고 0건) |
| `pnpm build:package` (.d.ts 포함) | ✅ 10/10 |
| `pnpm lint` | ✅ 0 errors |
| `@shoplflow/base` test (vitest) | ✅ 9/9 |
| 락파일 컴파일러 버전 | ✅ `6.0.3` 단일 |
| 배포 번들 포맷(CJS/ESM) | ✅ 변화 없음 |

## 참고 사항
- 설치 시 `typescript-eslint@8.57` 이 peer 로 `<6.0.0` 을 원한다는 **경고**가 뜨지만 (`strict-peer-dependencies=false`), 실제 lint/type-check 동작은 정상입니다. 추후 typescript-eslint 상향 시 사라집니다.
- `extension` 패키지는 `paths` 를 실제로 사용하므로 `baseUrl` 을 의도적으로 유지했습니다.
- **향후 TS 7 이행 시**: ES5 지원 중단을 결정하면 `target` 을 올리고 `ignoreDeprecations` 를 제거하면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
