### PR TITLE
fix(base): YearSelect 선택 년도 자동 스크롤 미동작 수정

### DIFF
--- a/.changeset/tidy-years-scroll.md
+++ b/.changeset/tidy-years-scroll.md
@@ -1,0 +1,7 @@
+---
+"@shoplflow/base": patch
+---
+
+fix: Datepickers/stepper/YearSelect 선택 년도 자동 스크롤(focus) 미동작 수정
+
+연도 목록의 노출 높이를 내부 `ul` 대신 실제 스크롤 컨테이너(SimpleBar viewport) 기준으로 측정하도록 변경했습니다. 이전에는 `closest('ul')`이 스크롤 영역이 아닌 전체 콘텐츠 높이를 가진 내부 `ul`을 참조해, 마지막 항목을 제외하면 스크롤 조건이 성립하지 않았습니다.

--- a/packages/base/src/components/Datepickers/stepper/YearSelect.tsx
+++ b/packages/base/src/components/Datepickers/stepper/YearSelect.tsx
@@ -45,11 +45,22 @@ const YearSelect = ({ optionList, className, parentClassName, activeValue, maxHe
 
     const selectedOptionIndex = optionList.findIndex((option) => option?.value === activeValue);
 
-    const heightPerOption = optionListRef.current[selectedOptionIndex]?.offsetHeight ?? 0;
-    const parentHeight = optionListRef.current[selectedOptionIndex]?.closest('ul')?.clientHeight ?? 0;
+    if (selectedOptionIndex < 0) {
+      return;
+    }
 
-    if (heightPerOption * (selectedOptionIndex + 1) >= parentHeight) {
-      simpleBarContentRef.current?.getScrollElement()?.scrollTo({ top: heightPerOption * selectedOptionIndex });
+    const scrollElement = simpleBarContentRef.current?.getScrollElement();
+    const heightPerOption = optionListRef.current[selectedOptionIndex]?.offsetHeight ?? 0;
+    // NOTICE: 노출 영역의 높이는 실제 스크롤 컨테이너(SimpleBar viewport) 기준으로 측정해야 합니다.
+    // 내부 마크업(ul 등)은 콘텐츠 전체 높이를 가지므로 기준으로 삼으면 스크롤 조건이 성립하지 않습니다.
+    const visibleHeight = scrollElement?.clientHeight ?? 0;
+
+    if (!scrollElement || !heightPerOption || !visibleHeight) {
+      return;
+    }
+
+    if (heightPerOption * (selectedOptionIndex + 1) > visibleHeight) {
+      scrollElement.scrollTo({ top: heightPerOption * selectedOptionIndex });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAllRefMounted, activeValue, maxHeight]);

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "noEmit": true,
-    "baseUrl": ".",
     "allowJs": false,
     "target": "esnext",
     "module": "esnext",
@@ -18,9 +17,9 @@
     "typeRoots": ["./src", "node_modules/@types"],
     "paths": {
       "@root/*": ["./*"],
-      "@src/*": ["src/*"],
-      "@assets/*": ["src/assets/*"],
-      "@pages/*": ["src/pages/*"],
+      "@src/*": ["./src/*"],
+      "@assets/*": ["./src/assets/*"],
+      "@pages/*": ["./src/pages/*"],
       "virtual:reload-on-update-in-background-script": ["./src/global.d.ts"],
       "virtual:reload-on-update-in-view": ["./src/global.d.ts"]
     }


### PR DESCRIPTION
#809(datepicker text accessibility)에서 접근성 개선을 위해 SimpleBar 내부에 새 ul을 추가하고 OptionList를 ul → div로 변경하면서, 스크롤 조건 판정에 사용하던 closest('ul')이 스크롤 영역이 아닌 콘텐츠 전체 높이를 가진 내부 ul을 참조하게 되어 선택 년도로 자동 스크롤되지 않았습니다.

노출 높이를 실제 스크롤 컨테이너(SimpleBar viewport)에서 직접 측정하도록
변경해 마크업 구조 변경에 영향받지 않게 했습니다. 선택 항목을 찾지 못한
경우와 측정값이 0인 경우 가드를 추가하고, 이미 완전히 보이는 항목에 대해
불필요한 스크롤이 발생하지 않도록 경계 조건을 >= 에서 > 로 조정했습니다.

## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->


<!-- 관련있는 이슈 번호(#000)를 PR 제목에 적어주세요. -->

<!-- ex) [SF-1234] 무슨 기능 업데이트 -->

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
