### PR TITLE
docs(mcp,skills): 아키텍쳐 문서 추가 및 README 보강, 릴리즈 배선 CI 검증 추가

### DIFF
--- a/.changeset/quick-pugs-yawn.md
+++ b/.changeset/quick-pugs-yawn.md
@@ -1,0 +1,13 @@
+---
+"@shoplflow/mcp": patch
+"@shoplflow/skills": patch
+---
+
+docs(mcp, skills): 아키텍쳐 문서 추가 + README 사용법 보강, MCP 릴리즈 배선 검증 CI 추가
+
+- `packages/{mcp,skills}/아키텍쳐.md` 신규: 레이어 구조, 추출 파이프라인, 설계 결정과 트레이드오프, 깨지기 쉬운 지점, 확장 가이드.
+- 두 패키지 README 보강: 클라이언트별 연결 설정, 툴 8종 전체 레퍼런스(파라미터 + 실제 응답), 인스톨러 플래그 레퍼런스, 트러블슈팅, 유지보수 가이드.
+- `@shoplflow/mcp`의 커밋된 메타데이터를 base 최신 소스로 재생성 (tokens 113→114, icons 451→473, components 63→65, story examples 142→149). 배포물은 빌드 시 재생성되므로 이전에도 최신이었고, 이번 변경은 리뷰 가능한 커밋본을 다시 맞춘 것입니다.
+- `pnpm --filter @shoplflow/mcp check:wiring` 추가: "base 릴리즈 → mcp 자동 재배포"를 성립시키는 세 가지 불변식(워크스페이스 devDeps · `build:package`의 `generate:metadata` 체인 · turbo의 `mcp#build:package` 스케줄링)을 검증합니다. 이 중 하나가 빠져도 빌드는 통과하고 재배포만 조용히 멈추므로 실행 가능한 검사로 고정했습니다.
+- PR CI(`build-test.yml`)에 배선 검증 + 커밋된 메타데이터 신선도 검사 추가.
+- `package.json`(`//` 노트) · `turbo.json` · `generate-metadata.cjs`에 위 결합 관계를 주석으로 명시.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,6 +36,37 @@ jobs:
       - name: 전체패키지를 빌드하고 있어요.
         run: pnpm build
 
+      # base 릴리즈 → mcp 재배포 연동은 package.json·turbo.json·.changeset/config.json에
+      # 흩어진 설정들이 맞물려 만들어집니다. 하나가 빠져도 빌드는 통과하고 조용히 재배포만
+      # 멈추므로, 불변식을 실행 가능한 검사로 고정합니다. (packages/mcp/아키텍쳐.md 6절)
+      - name: MCP 릴리즈 배선을 검증하고 있어요.
+        run: pnpm --filter @shoplflow/mcp check:wiring
+
+      # 커밋된 src/data/*.json이 base 소스와 일치하는지 확인합니다.
+      # 배포물 자체는 build:package가 매번 재생성하므로 항상 최신이지만, 커밋본이 밀리면
+      # "생성물을 커밋해서 PR diff로 변경 영향을 리뷰한다"는 설계 의도가 무너집니다.
+      #
+      # 앞선 `pnpm build`에 의존하지 않고 generate:metadata를 명시적으로 다시 실행합니다.
+      # turbo가 build:package를 캐시 히트시키면 스크립트가 아예 실행되지 않아(outputs가
+      # dist/**뿐이라 src/data는 복원 대상도 아님) diff가 비어 보이는 위양성이 생깁니다.
+      # 단, 아이콘 배럴(assets의 build:icons 산출물)이 필요하므로 `pnpm build` 뒤에 둡니다.
+      - name: MCP 메타데이터 최신 여부를 확인하고 있어요.
+        run: |
+          pnpm --filter @shoplflow/mcp generate:metadata
+          # HEAD와 직접 비교 — 스테이징 여부와 무관하게 "커밋된 것"과 대조합니다.
+          if ! git diff --quiet HEAD -- packages/mcp/src/data/; then
+            echo "::error::커밋된 MCP 메타데이터가 base 소스와 어긋나 있어요. 아래 명령으로 재생성 후 커밋해주세요:"
+            echo "::error::  pnpm --filter @shoplflow/mcp generate:metadata && git add packages/mcp/src/data"
+            echo ""
+            echo "--- 변경된 파일 ---"
+            git diff --stat HEAD -- packages/mcp/src/data/
+            echo ""
+            echo "--- 상세 diff (앞부분 200줄) ---"
+            git diff HEAD -- packages/mcp/src/data/ | head -200
+            exit 1
+          fi
+          echo "✓ 커밋된 MCP 메타데이터가 base 소스와 일치해요."
+
       - name: 테스트 Status와 Color를 설정하고 있어요.
         id: set_status_and_color
         if: always()

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,42 +1,62 @@
 # @shoplflow/mcp
 
 Model Context Protocol (MCP) server that exposes the shoplflow design system to AI coding agents
-(Claude Code, Cursor, …) so they generate UI against **real** tokens, components, and icons instead
+(Claude Code, Cursor, Codex, …) so they generate UI against **real** tokens, components, and icons instead
 of hallucinating them.
 
-## Architecture
+```tsx
+// Without the MCP — plausible, but nothing here exists
+<Button variant="primary" size="medium" color="#3B82F6" />
+<Icon name="plus" />
 
-Metadata is **generated at build time** from the same sources that produce the shipped library, then
-served by a thin stdio server. This makes drift structurally impossible — the MCP can never describe a
-token or component that differs from what actually ships.
-
-```
-tokens.json    ─┐
-*-assets barrel ─┤ scripts/generate-metadata.cjs ─► src/data/*.generated.json ─► MCP server (stdio)
-*.types.ts     ─┘   (build step)                     (bundled into the bin)
+// With the MCP — looked up from the shipped library
+<Button styleVar="PRIMARY" sizeVar="M" />
+<Icon iconSource={AddIcon} sizeVar="S" color="neutral500" />
 ```
 
-## Roadmap
+> 내부 구조·설계 결정·확장 가이드는 [아키텍쳐.md](./아키텍쳐.md)를 참고하세요.
 
-| Phase | Surface | Source | Status |
-|-------|---------|--------|--------|
-| 1 | Design tokens (`list_tokens`, `get_token`, `shoplflow://tokens`) | `tokens.json` | ✅ done |
-| 2 | Icon search (`search_icon`) | `*-assets` barrels | ✅ done |
-| 3 | Component API (`search_component`, `get_component_api`) | `*.types.ts` | ✅ done |
-| 4 | Usage examples (`get_usage_example`) | `*.stories.tsx` | ✅ done |
-| 5 | Setup & environment (`get_setup_guide`, `check_environment`, server `instructions`) | provider + `setup.curated.json` | ✅ done |
+**Contents:** [Quick start](#quick-start) · [Verify](#verify-the-connection) · [Tools](#tool-reference) · [Resources](#resources) · [Working with an agent](#working-with-an-agent) · [What's served](#whats-served) · [Development](#local-development) · [Troubleshooting](#troubleshooting)
 
-## Develop
+---
+
+## Quick start
+
+The server runs over **stdio** and needs no auth, no network, and no config — the whole design-system
+catalog is bundled into the published binary.
+
+### Claude Code
+
+Easiest path — install the plugin, which wires up this MCP **and** the [`@shoplflow/skills`](../skills) agent skills in one step:
 
 ```bash
-pnpm --filter @shoplflow/mcp generate:metadata   # regenerate metadata from sources
-pnpm --filter @shoplflow/mcp build:package        # generate + bundle to dist/
-pnpm --filter @shoplflow/mcp start                # run the built server over stdio
+/plugin marketplace add shopl/shoplflow
+/plugin install shoplflow@shoplflow-marketplace
 ```
 
-## Connect (consuming app)
+MCP only:
 
-Add to the client's MCP config (Claude Code shown):
+```bash
+claude mcp add shoplflow -- npx -y @shoplflow/mcp
+```
+
+Or commit it to the project so the whole team gets it — `.mcp.json` at the repo root:
+
+```json
+{
+  "mcpServers": {
+    "shoplflow": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@shoplflow/mcp"]
+    }
+  }
+}
+```
+
+### Cursor
+
+`.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (global):
 
 ```json
 {
@@ -49,44 +69,556 @@ Add to the client's MCP config (Claude Code shown):
 }
 ```
 
-## Tools
+### Codex
 
-**Tokens (Phase 1)**
-- **`list_tokens`** — discover token names/values; filter by `domain` (`shared` | `shopl` | `hada`), `type`, or a `query` substring.
-- **`get_token`** — full record for one token by exact `name` (+ optional `domain`).
-- Resource **`shoplflow://tokens`** — the entire catalog as JSON.
+`~/.codex/config.toml`:
 
-Typography tokens (e.g. `body1_700`) are applied via the `typography` prop / CSS class, not a CSS variable —
-the served records carry `className` for those and `cssVar` for the rest.
+```toml
+[mcp_servers.shoplflow]
+command = "npx"
+args = ["-y", "@shoplflow/mcp"]
+```
 
-**Icons (Phase 2)**
-- **`search_icon`** — find icons by name or meaning; filter by `domain` (`shopl` | `hada`) and `limit`.
-  Returns the raw name (`IcAdd`) and public alias (`AddIcon`), both importable from the brand asset
-  package and usable as `<Icon iconSource={AddIcon} />`. Icon sets differ per brand.
+### VS Code (GitHub Copilot)
 
-**Components (Phase 3)**
-- **`search_component`** — discover `@shoplflow/base` components by name, module, prop, or variant value;
-  filter by `group` (module) and `limit`. Compound components are listed per part (e.g. `ModalContainer`, `ModalHeader`).
-- **`get_component_api`** — full API for one component by exact name: props (with JSDoc + optionality),
-  exact variant values (`sizeVar`/`styleVar`/…), polymorphism (`as` + default element), and native-HTML-attr passthrough.
-- Resource **`shoplflow://components`** — compact index of every component.
+`.vscode/mcp.json`:
 
-Component metadata is extracted from `*.types.ts` via ts-morph (build-time only), mirroring how the library
-composes props from the documented mixins in `utils/type/ComponentProps.ts`.
+```json
+{
+  "servers": {
+    "shoplflow": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@shoplflow/mcp"]
+    }
+  }
+}
+```
 
-**Usage examples (Phase 4)**
-- **`get_usage_example`** — real, copy-pasteable examples for a component, extracted from its stories
-  (`args` + `render` JSX, with `play`/test code stripped). Accepts a module name (`Button`, `Modal`) or a
-  component name from `get_component_api` (`ModalContainer` resolves to the `Modal` stories).
+### Any other MCP client
 
-**Setup & environment (Phase 5)**
-- Server **`instructions`** — an always-on preflight (surfaced at connect) so the agent never skips the
-  mandatory `ShoplflowProvider` + global-CSS setup, or the client-only / Next.js constraint.
-- **`get_setup_guide`** — required style import, the Provider wrapper + `domain` prop, peer deps, and a
-  ready-to-paste snippet (synthesized from the real provider/exports, so it can't reference a wrong import).
-- **`check_environment`** — per-framework support (Vite/CRA supported; Next.js Pages constrained; Next.js
-  App Router needs a `'use client'` boundary + Emotion registry), with workarounds.
+Anything that speaks stdio MCP works — the command is always:
 
-Auto facts (provider props, CSS exports, peer deps) come from `@shoplflow/base`; the curated guidance
-(setup steps, framework constraints, the `instructions` text) lives in **`setup.curated.json`** — the one
-file the team edits. Keep the `Next.js` entries in sync with the library's actual support stance.
+```bash
+npx -y @shoplflow/mcp
+```
+
+Or install it and use the bin directly:
+
+```bash
+npm i -g @shoplflow/mcp && shoplflow-mcp
+```
+
+Requires **Node ≥ 18**.
+
+---
+
+## Verify the connection
+
+After restarting your agent, ask it something only this server can answer:
+
+> "shoplflow에서 primary300 토큰 값이 뭐야?"
+
+A working connection returns `#3299fe` **via a `get_token` call** (you should see the tool invocation).
+If the agent answers from guesswork without calling a tool, it isn't connected.
+
+In Claude Code you can also list it explicitly:
+
+```bash
+claude mcp list          # shoplflow should appear as connected
+```
+
+**Connect-time preflight.** On connect, the server hands the client an `instructions` string that the agent
+keeps in context for the whole session:
+
+> MANDATORY shoplflow setup before rendering ANY `@shoplflow/base` component: (1) import `@shoplflow/base/styles`
+> at the app entry; (2) wrap the tree in `<ShoplflowProvider domain="SHOPL" | "HADA">`. These components are
+> CLIENT-ONLY … Next.js App Router requires a `'use client'` boundary plus an Emotion registry.
+
+This is why the agent won't forget the provider even if you never mention it.
+
+---
+
+## Tool reference
+
+Eight tools, organised as **discover → detail**. List tools return summaries; detail tools return everything.
+That split keeps the agent's context small — pulling all 65 component APIs at once would cost tens of
+thousands of tokens.
+
+| Tool                                      | Use it to                       | Returns                         |
+| ----------------------------------------- | ------------------------------- | ------------------------------- |
+| [`list_tokens`](#list_tokens)             | discover token names/values     | summaries                       |
+| [`get_token`](#get_token)                 | get one token in full           | full record                     |
+| [`search_icon`](#search_icon)             | find an icon by name or meaning | name + alias + import           |
+| [`search_component`](#search_component)   | discover components             | summaries + variants            |
+| [`get_component_api`](#get_component_api) | get one component's full API    | props + variants + polymorphism |
+| [`get_usage_example`](#get_usage_example) | get real usage code             | story-derived examples          |
+| [`get_setup_guide`](#get_setup_guide)     | scaffold correct setup          | provider + CSS + snippet        |
+| [`check_environment`](#check_environment) | check framework support         | support status + workaround     |
+
+---
+
+### `list_tokens`
+
+Discover exact token names and values before writing UI code.
+
+| Param    | Type                            | Required | Description                                                                                                                |
+| -------- | ------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `domain` | `"shared" \| "shopl" \| "hada"` | –        | `shared` = palette/spacing/radius/weights/shadows (brand-agnostic). `shopl`/`hada` = typography + primary/semantic colors. |
+| `type`   | `string`                        | –        | One of `color`, `spacing`, `borderRadius`, `fontWeights`, `typography`, `boxShadow`.                                       |
+| `query`  | `string`                        | –        | Case-insensitive substring against the token **name or value**.                                                            |
+
+```jsonc
+// list_tokens({ type: "color", query: "primary" })
+{
+  "count": 10, // primary100/150/200/300/400 × shopl + hada
+  "tokens": [
+    {
+      "name": "primary300",
+      "type": "color",
+      "domain": "shopl",
+      "value": "#3299fe",
+      "cssVar": "--primary300",
+      "className": null,
+    },
+  ],
+}
+```
+
+> **`cssVar` vs `className`.** Most tokens are CSS custom properties (`var(--primary300)`).
+> Typography tokens are **not** — they're applied as a class or via the `typography` prop
+> (`<Text typography="body1_700" />`), so they carry `className` instead. The agent uses this
+> field to pick the right consumption pattern.
+
+---
+
+### `get_token`
+
+Full record for one token by exact name.
+
+| Param    | Type                            | Required | Description                                                    |
+| -------- | ------------------------------- | -------- | -------------------------------------------------------------- |
+| `name`   | `string`                        | ✅       | Exact token name, e.g. `primary300`, `body1_700`, `spacing08`. |
+| `domain` | `"shared" \| "shopl" \| "hada"` | –        | Disambiguate — the same name can exist per brand.              |
+
+A miss returns suggestions rather than an error, so the agent can self-correct:
+
+```jsonc
+// get_token({ name: "primaryX" })
+{ "found": false, "name": "primaryX", "suggestions": ["primary100 (shopl)", "primary200 (shopl)", …] }
+```
+
+---
+
+### `search_icon`
+
+Find icons by name **or meaning**. Both the raw name (`IcAdd`) and the public alias (`AddIcon`) are
+importable and both are returned.
+
+| Param    | Type                | Required | Description                                             |
+| -------- | ------------------- | -------- | ------------------------------------------------------- |
+| `query`  | `string`            | ✅       | Name or keywords — `"add"`, `"chat bot"`, `"calendar"`. |
+| `domain` | `"shopl" \| "hada"` | –        | Restrict to one brand's icon set.                       |
+| `limit`  | `number` (≤50)      | –        | Max results, default 15.                                |
+
+```jsonc
+// search_icon({ query: "trash", domain: "shopl" })
+{
+  "query": "trash",
+  "count": 2,
+  "icons": [
+    {
+      "name": "IcTrash",
+      "alias": "TrashIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+    },
+    {
+      "name": "IcTrashLine",
+      "alias": "TrashLineIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+    },
+  ],
+}
+```
+
+> **Multi-word queries narrow, they don't broaden.** Every term must match — `"chat bot"` returns only
+> `IcAiChatBot`, not everything chat-related. Search first, then use `<Icon iconSource={TrashIcon} />`.
+>
+> **Icon sets differ per brand.** An icon in `shopl` may not exist in `hada`. Pass `domain` when the app
+> targets one brand.
+
+---
+
+### `search_component`
+
+Discover components by name, module, prop name, or variant value.
+
+| Param   | Type           | Required | Description                                                      |
+| ------- | -------------- | -------- | ---------------------------------------------------------------- |
+| `query` | `string`       | ✅       | e.g. `"button"`, `"modal"`, `"date"`, `"styleVar"`, `"loading"`. |
+| `group` | `string`       | –        | Restrict to one module (the component folder, e.g. `"Modal"`).   |
+| `limit` | `number` (≤50) | –        | Max results, default 20.                                         |
+
+Compound components are listed **per part** — searching `"modal"` returns `ModalContainer`,
+`ModalHeader`, `ModalContents`, … not a single `Modal` entry.
+
+```jsonc
+// search_component({ query: "button" })
+{
+  "count": 11, // Button, ChipButton, DropdownButton, IconButton, SplitButton, ToggleButton, …
+  "components": [
+    {
+      "name": "Button",
+      "group": "Button",
+      "polymorphic": true,
+      "variants": [
+        { "prop": "sizeVar", "values": ["S", "M", "XS"] },
+        {
+          "prop": "styleVar",
+          "values": ["PRIMARY", "SECONDARY", "SOLID", "GHOST"],
+        },
+      ],
+      "propCount": 9,
+    },
+  ],
+}
+```
+
+---
+
+### `get_component_api`
+
+Everything about one component.
+
+| Param  | Type     | Required | Description                                                              |
+| ------ | -------- | -------- | ------------------------------------------------------------------------ |
+| `name` | `string` | ✅       | Exact component name, case-insensitive — `"Button"`, `"ModalContainer"`. |
+
+```jsonc
+// get_component_api({ name: "Button" })
+{
+  "found": true,
+  "component": {
+    "name": "Button",
+    "group": "Button",
+    "importFrom": "@shoplflow/base",
+    "polymorphic": true, // accepts `as`
+    "defaultElement": "button", // renders <button> by default
+    "nativeAttrs": "button", // forwards native <button> attributes
+    "variants": [
+      { "prop": "sizeVar", "values": ["S", "M", "XS"] },
+      {
+        "prop": "styleVar",
+        "values": ["PRIMARY", "SECONDARY", "SOLID", "GHOST"],
+      },
+    ],
+    "props": [
+      {
+        "name": "color",
+        "optional": true,
+        "type": "ColorTokens",
+        "description": "텍스트 혹은 아이콘의 색상을 설정합니다. styleVar이 있는 경우 메인색상을 설정합니다.",
+      },
+      {
+        "name": "isLoading",
+        "optional": true,
+        "type": "boolean",
+        "description": "로딩 여부를 설정합니다.",
+      },
+    ],
+  },
+}
+```
+
+Field meanings:
+
+| Field            | Meaning                                                                                                                                  |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `polymorphic`    | Accepts an `as` prop — `<Button as="a" href="…">`.                                                                                       |
+| `defaultElement` | The element rendered when `as` is omitted.                                                                                               |
+| `nativeAttrs`    | Forwards that element's native HTML attributes (`onClick`, `type`, `aria-*`, …). Not enumerated — there are hundreds.                    |
+| `variants`       | The **exact** allowed values, read from the `as const` enums in the source. Nothing else is valid.                                       |
+| `props`          | Component-specific props with JSDoc (Korean, straight from the library) and optionality. Types longer than 80 chars are elided with `…`. |
+
+Misses return `suggestions`, same as `get_token`.
+
+---
+
+### `get_usage_example`
+
+Real, copy-pasteable usage extracted from the component's Storybook stories — `args` and `render` JSX,
+with `play`/`parameters`/`argTypes` test noise stripped.
+
+| Param  | Type     | Required | Description                                                                                                                                |
+| ------ | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name` | `string` | ✅       | Module name (`"Button"`, `"Modal"`) **or** a component name from `get_component_api` (`"ModalContainer"` resolves to the `Modal` stories). |
+
+```jsonc
+// get_usage_example({ name: "Button" })
+{
+  "found": true,
+  "component": "Button",
+  "group": "Button",
+  "examples": [
+    {
+      "story": "Playground",
+      "args": "{ styleVar: 'PRIMARY', sizeVar: 'M', children: 'Button', disabled: false }",
+    },
+    {
+      "story": "Variants",
+      "code": "<div style={flexWrap}>\n  <Button {...args} styleVar='PRIMARY'>Primary</Button>\n  <Button {...args} styleVar='SOLID' color='neutral300'>Solid</Button>\n</div>",
+    },
+  ],
+}
+```
+
+> Stories are the best usage source because they're rendered in CI — an example that broke would fail the build.
+> Up to 8 examples per module; long code is clipped at ~1200 chars.
+
+---
+
+### `get_setup_guide`
+
+The prerequisite setup before **any** `@shoplflow/base` component renders. Takes no arguments.
+
+```jsonc
+{
+  "provider": {
+    "name": "ShoplflowProvider",
+    "importFrom": "@shoplflow/base",
+    "clientOnly": true,
+    "clientReasons": [
+      "framer-motion (LazyMotion)",
+      "Modal/Popper portals",
+      "DOM theming hook (data-shoplflow)",
+      "Emotion CSS-in-JS",
+    ],
+    "props": [
+      {
+        "name": "domain",
+        "type": "DomainType",
+        "optional": true,
+        "default": "SHOPL",
+        "values": ["SHOPL", "HADA"],
+      },
+    ],
+  },
+  "styles": [
+    {
+      "specifier": "@shoplflow/base/styles",
+      "role": "design-token CSS vars + typography classes (required)",
+    },
+    { "specifier": "@shoplflow/base/reset", "role": "CSS reset (optional)" },
+  ],
+  "peerDependencies": {
+    "@emotion/react": "^11",
+    "@emotion/styled": "^11",
+    "react": "^18",
+    "react-dom": "^18",
+  },
+  "setupSteps": ["…"],
+  "snippet": "import { ShoplflowProvider } from '@shoplflow/base';\nimport '@shoplflow/base/styles';\n\n<ShoplflowProvider domain=\"SHOPL\">\n  <App />\n</ShoplflowProvider>",
+}
+```
+
+> The `snippet` is **synthesised from the real provider and package exports**, so it can never reference a
+> wrong import path or a prop that doesn't exist.
+
+Call this before scaffolding a project. For framework-specific caveats, pair it with `check_environment`.
+
+---
+
+### `check_environment`
+
+Whether — and how — shoplflow works in a given framework. Components are client-only, so SSR/RSC
+frameworks have caveats.
+
+| Param       | Type     | Required | Description                                                                         |
+| ----------- | -------- | -------- | ----------------------------------------------------------------------------------- |
+| `framework` | `string` | –        | e.g. `"next app router"`, `"vite"`, `"next pages"`. Omit to list every environment. |
+
+| Environment                | Support             | Summary                                                                                                                                                                            |
+| -------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Vite / CRA (SPA, CSR)      | ✅ supported        | Recommended. Import the styles and wrap with the provider at the entry point.                                                                                                      |
+| Next.js — Pages Router     | ⚠️ constrained      | Renders, but FOUC without Emotion SSR. Workaround: wrap in `_app.tsx`, add `extractCriticalToChunks` in `_document.tsx`.                                                           |
+| Next.js — App Router (RSC) | ⛔ needs workaround | Cannot render inside a Server Component. Workaround: `'use client'` provider wrapper + Emotion registry (`useServerInsertedHTML`); keep every consumer inside the client boundary. |
+
+Unknown input returns the full list rather than an empty result.
+
+---
+
+## Resources
+
+For clients that prefer reading a document over calling tools.
+
+| URI                      | Content                                                                           |
+| ------------------------ | --------------------------------------------------------------------------------- |
+| `shoplflow://tokens`     | The entire token catalog as JSON (all 114 records with counts by type/domain).    |
+| `shoplflow://components` | Compact index of every component — name, group, polymorphism, variant prop names. |
+
+---
+
+## Working with an agent
+
+You don't need to name the tools — the descriptions steer the agent. But knowing the flow helps you
+diagnose a bad result.
+
+```
+"shoplflow로 삭제 버튼 만들어줘"
+  ├ search_component("button")   → Button, IconButton, SplitButton, ToggleButton, …
+  ├ get_component_api("Button")  → exact styleVar/sizeVar values + props
+  ├ get_usage_example("Button")  → real JSX from the stories
+  ├ search_icon("trash")         → IcTrash / TrashIcon + import path
+  └ list_tokens({type:"color"})  → exact color token keys
+```
+
+**Prompts that use the server well**
+
+| Goal                | Ask                                                                               |
+| ------------------- | --------------------------------------------------------------------------------- |
+| Correct scaffolding | "Vite 앱에 shoplflow 셋업해줘" → triggers `get_setup_guide` + `check_environment` |
+| Exact variants      | "Button에 어떤 styleVar 값이 있어?" → `get_component_api`                         |
+| Find an icon        | "휴지통 아이콘 뭐 써야 해?" → `search_icon`                                       |
+| Match the design    | "이 카드 배경을 shoplflow 뉴트럴 토큰으로 바꿔줘" → `list_tokens`                 |
+| Framework check     | "Next.js App Router에서 shoplflow 써도 돼?" → `check_environment`                 |
+
+**Pair with the skills package.** The MCP gives an agent _facts_; [`@shoplflow/skills`](../skills) gives it
+_idioms_ — the setup order, the KEY-vs-VALUE distinction, the `styleVar`/`sizeVar` convention. Installing the
+plugin gets both. See [../skills/README.md](../skills/README.md).
+
+---
+
+## What's served
+
+Everything is generated at build time from the same files that produce the shipped library, so the served
+metadata can't describe something that differs from what ships.
+
+| Surface              | Count                                                                                          | Source                                              |
+| -------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| Design tokens        | **114** (color 44 · typography 47 · spacing 13 · borderRadius 6 · fontWeights 3 · boxShadow 1) | `base/src/styles/tokens.json`                       |
+| Icons                | **473** (shopl 369 · hada 104)                                                                 | `{shopl,hada}-assets` barrels                       |
+| Component APIs       | **65 cards** across 43 modules (19 with variants)                                              | `base/src/components/**/*.types.ts`                 |
+| Usage examples       | **149** across 42 modules                                                                      | `base/src/components/**/*.stories.tsx`              |
+| Setup & environments | provider + 2 CSS exports + 3 frameworks                                                        | `base` provider/package.json + `setup.curated.json` |
+
+```
+tokens.json    ─┐
+*-assets barrel ─┤ scripts/generate-metadata.cjs ─► src/data/*.generated.json ─► MCP server (stdio)
+*.types.ts     ─┤   (build step, ts-morph)          (inlined into the bin)
+*.stories.tsx  ─┘
+```
+
+Full pipeline details in [아키텍쳐.md](./아키텍쳐.md).
+
+---
+
+## Local development
+
+```bash
+pnpm --filter @shoplflow/mcp generate:metadata   # regenerate metadata from the library sources
+pnpm --filter @shoplflow/mcp build:package       # generate + bundle to dist/
+pnpm --filter @shoplflow/mcp dev                 # generate + tsup --watch
+pnpm --filter @shoplflow/mcp start               # run the built server over stdio
+pnpm --filter @shoplflow/mcp check:wiring        # verify the base-release coupling is intact
+```
+
+`build:package` always runs `generate:metadata` first, so a normal build can't ship stale data.
+
+### Smoke test
+
+The only end-to-end check — spins up `dist/index.js` with a real MCP client and exercises every tool:
+
+```bash
+pnpm --filter @shoplflow/mcp build:package
+node packages/mcp/scripts/smoke.mjs
+```
+
+Expected tail: `✓ smoke test passed`. Run it after touching `server.ts` or any extractor.
+
+### Point your agent at the local build
+
+The repo root `.mcp.json` already does this for monorepo development:
+
+```json
+{
+  "mcpServers": {
+    "shoplflow": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["packages/mcp/dist/index.js"]
+    }
+  }
+}
+```
+
+Rebuild (`build:package`) and restart the agent to pick up changes.
+
+### After changing the library
+
+Regenerate and **commit the generated JSON** — it's tracked in git so releases are reproducible and diffs
+are reviewable.
+
+| You changed                          | Regenerate affects          |
+| ------------------------------------ | --------------------------- |
+| `tokens.json`                        | `tokens.generated.json`     |
+| SVG assets (after `build:assets`)    | `icons.generated.json`      |
+| a `*.types.ts`                       | `components.generated.json` |
+| a `*.stories.tsx`                    | `stories.generated.json`    |
+| provider / `base` exports / peerDeps | `setup.generated.json`      |
+
+Sanity-check the console summary (`✓ tokens: 114 …`) — a sudden drop in a count means an extractor's
+assumption broke.
+
+**CI enforces this.** `build-test.yml` regenerates the metadata on every PR and fails if the committed
+JSON differs, with the exact command to fix it. Without that gate the committed copy silently rots and
+the "review the effect of a base change in the PR diff" benefit disappears.
+
+### Release coupling (why `check:wiring` exists)
+
+A `@shoplflow/base` release automatically republishes this package with freshly extracted metadata. That
+behaviour isn't declared in one place — it emerges from settings spread across `package.json`,
+`turbo.json`, and `.changeset/config.json`:
+
+| Piece                                                        | Removing it…                                                     |
+| ------------------------------------------------------------ | ---------------------------------------------------------------- |
+| `@shoplflow/{base,shopl-assets,hada-assets}` in devDeps      | stops changesets from bumping mcp → **mcp is never republished** |
+| `generate:metadata &&` in `build:package`                    | allows a build path that bundles previously generated JSON       |
+| turbo scheduling `mcp#build:package` under `turbo run build` | means CI's `pnpm build` never produces `dist/` before publish    |
+
+Each removal keeps the build green — the failure is silent, and consumers just keep receiving stale
+metadata. `check:wiring` asserts all three and runs on every PR. Details in
+[아키텍쳐.md §6](./아키텍쳐.md).
+
+### Editing the setup guidance
+
+`setup.curated.json` is the **one file the team edits by hand**. It holds `setupSteps`, per-framework
+`environments`, and the connect-time `instructions`. Everything else (provider props, CSS exports, peer deps)
+is extracted from code and must not be duplicated there.
+
+Keep the Next.js entries in sync with the library's actual support stance — the App Router entry currently
+carries a `verify` note flagging it as an inferred, unratified position.
+
+---
+
+## Troubleshooting
+
+| Symptom                           | Cause                                   | Fix                                                                                                                                              |
+| --------------------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Agent doesn't call any tool       | Server not connected                    | `claude mcp list` / check the client's MCP panel. Restart the agent after editing config.                                                        |
+| `npx` fails or hangs              | Node < 18, or no network on first fetch | `node -v`; run `npx -y @shoplflow/mcp` in a terminal to see the real error. First run downloads the package.                                     |
+| Connection drops immediately      | Something wrote to stdout               | stdout is reserved for JSON-RPC. Any `console.log` in the server corrupts the protocol — logs must go to `stderr`.                               |
+| Tools work but data looks stale   | Metadata not regenerated                | `pnpm --filter @shoplflow/mcp build:package`, restart the agent. Published versions ship the metadata frozen at release time — bump the package. |
+| An icon isn't found               | Wrong brand                             | Icon sets differ per brand; retry `search_icon` without `domain`, or with the other one.                                                         |
+| A component isn't found           | Compound part name                      | Search the module (`search_component({ query: "modal" })`) to see the real part names.                                                           |
+| Agent still skips the provider    | Client ignores `instructions`           | Some clients don't surface server instructions. Install [`@shoplflow/skills`](../skills) so the setup rule arrives as a skill too.               |
+| Multi-word search returns nothing | AND semantics                           | Every term must match. Try fewer/shorter terms.                                                                                                  |
+
+---
+
+## Related
+
+- [아키텍쳐.md](./아키텍쳐.md) — internal architecture, design decisions, extension guide
+- [`@shoplflow/skills`](../skills) — agent skills + the plugin that bundles this server
+- [CLAUDE.md](../../CLAUDE.md) — monorepo guide

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -27,17 +27,35 @@
   "publishConfig": {
     "access": "public"
   },
+  "//scripts": [
+    "build:package MUST keep `generate:metadata &&` at the front. It is what guarantees the",
+    "published bundle can never carry stale design-system metadata — there is no build path",
+    "that skips extraction. Verified by `check:wiring`."
+  ],
   "scripts": {
     "generate:metadata": "node scripts/generate-metadata.cjs",
     "build:package": "pnpm generate:metadata && rm -rf dist/ && tsup",
     "dev": "pnpm generate:metadata && tsup --watch",
     "start": "node dist/index.js",
+    "check:wiring": "node scripts/check-release-wiring.cjs",
     "type-check": "tsc --noEmit || true"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
     "zod": "^3.23.8"
   },
+  "//devDependencies": [
+    "DO NOT REMOVE the three @shoplflow/* workspace deps below just because nothing imports them.",
+    "They are not runtime deps — they are the wire that couples this package to a base release:",
+    "  1. turbo reads them to order `build:package` after base/assets have built.",
+    "  2. changesets reads them to treat mcp as a dependent of base, so a base version bump",
+    "     patch-bumps mcp too (.changeset/config.json -> updateInternalDependents: always).",
+    "     That is the ONLY reason a base-only change republishes mcp with fresh metadata.",
+    "Removing them breaks NOTHING visibly: extraction still works (scripts read ../../base/src",
+    "by relative path), the build still passes — but mcp silently stops being republished and",
+    "consumers keep receiving stale metadata forever. Guarded by `pnpm check:wiring`.",
+    "See 아키텍쳐.md section 6."
+  ],
   "devDependencies": {
     "@shoplflow/base": "workspace:*",
     "@shoplflow/hada-assets": "workspace:*",

--- a/packages/mcp/scripts/check-release-wiring.cjs
+++ b/packages/mcp/scripts/check-release-wiring.cjs
@@ -1,0 +1,165 @@
+/**
+ * Guards the three invariants that make "a @shoplflow/base release also republishes
+ * @shoplflow/mcp with fresh metadata" true.
+ *
+ * That behaviour is not declared anywhere as a single rule — it emerges from separate settings in
+ * package.json, turbo.json and .changeset/config.json. Each can be removed by a well-meaning
+ * cleanup without breaking a build, so the failure mode is silent: extraction keeps working, CI
+ * stays green, and consumers quietly keep receiving stale metadata. This script turns those
+ * implicit couplings into an executable, failing check.
+ *
+ *   1. workspace devDeps  — changesets needs them to bump mcp as a dependent of base,
+ *                           and turbo needs them to order the builds
+ *   2. build:package chain — `generate:metadata &&` must run before the bundler
+ *   3. turbo scheduling    — `turbo run build` must actually schedule mcp#build:package,
+ *                            even though mcp has no `build` script
+ *
+ * Run: pnpm --filter @shoplflow/mcp check:wiring
+ */
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const PKG_DIR = path.resolve(__dirname, "..");
+const REPO_ROOT = path.resolve(PKG_DIR, "../..");
+const PKG_NAME = "@shoplflow/mcp";
+
+// The workspace packages whose sources the extractors read (see generate-metadata.cjs).
+const REQUIRED_WORKSPACE_DEPS = [
+  "@shoplflow/base",
+  "@shoplflow/shopl-assets",
+  "@shoplflow/hada-assets",
+];
+
+const failures = [];
+const notes = [];
+
+function fail(title, detail) {
+  failures.push({ title, detail });
+}
+
+const readJson = (p) => JSON.parse(fs.readFileSync(p, "utf8"));
+
+/* ── 1. workspace devDependencies ────────────────────────────────────────────
+ * Nothing imports these at runtime, which is exactly why they get deleted. They are the only
+ * signal changesets has that mcp must be version-bumped when base is.
+ */
+function checkWorkspaceDeps(pkg) {
+  const declared = { ...pkg.dependencies, ...pkg.devDependencies };
+  const missing = REQUIRED_WORKSPACE_DEPS.filter((d) => !declared[d]);
+  if (missing.length) {
+    fail(
+      `${PKG_NAME} is missing workspace dependencies: ${missing.join(", ")}`,
+      [
+        "These are NOT unused. Without them:",
+        "  · changesets stops treating mcp as a dependent of base, so a base release no longer",
+        "    patch-bumps mcp — mcp is never republished and consumers keep stale metadata.",
+        "  · turbo loses the ordering that builds base/assets before mcp#build:package.",
+        "Nothing will error; the breakage is silent. Restore them as `workspace:*` devDependencies.",
+      ].join("\n"),
+    );
+    return;
+  }
+  const wrongRange = REQUIRED_WORKSPACE_DEPS.filter(
+    (d) => !String(declared[d]).startsWith("workspace:"),
+  );
+  if (wrongRange.length) {
+    fail(
+      `Workspace deps must use the \`workspace:\` protocol: ${wrongRange.join(", ")}`,
+      "A registry range would resolve to a published copy instead of the local sources the extractors read.",
+    );
+  }
+}
+
+/* ── 2. build:package always regenerates ─────────────────────────────────── */
+function checkBuildChain(pkg) {
+  const script = pkg.scripts?.["build:package"] ?? "";
+  if (!/generate:metadata\s*&&/.test(script)) {
+    fail(
+      "`build:package` no longer runs `generate:metadata` before bundling",
+      [
+        `  current: ${script || "(missing)"}`,
+        "  expected it to start with: pnpm generate:metadata && …",
+        "Without this there is a build path that publishes the previously generated JSON,",
+        "so the bundle can ship metadata that no longer matches base.",
+      ].join("\n"),
+    );
+  }
+}
+
+/* ── 3. turbo actually schedules mcp#build:package ────────────────────────────
+ * mcp defines no `build` script, so this depends on turbo expanding the task graph across all
+ * packages. If that ever changes, `pnpm build` in CI stops producing dist/ before publish.
+ * A turbo failure here is reported as a note, not a failure — we only assert on a successful run.
+ */
+function checkTurboSchedule() {
+  let raw;
+  try {
+    raw = execFileSync(
+      "pnpm",
+      ["exec", "turbo", "run", "build", "--dry=json"],
+      {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        maxBuffer: 32 * 1024 * 1024,
+      },
+    );
+  } catch {
+    notes.push(
+      "turbo dry-run could not be executed — skipped the scheduling check (not treated as a failure).",
+    );
+    return;
+  }
+
+  let plan;
+  try {
+    plan = JSON.parse(raw);
+  } catch {
+    notes.push(
+      "turbo dry-run output was not JSON — skipped the scheduling check.",
+    );
+    return;
+  }
+
+  const taskId = `${PKG_NAME}#build:package`;
+  const task = (plan.tasks ?? []).find((t) => t.taskId === taskId);
+  if (!task || task.command === "<NONEXISTENT>") {
+    fail(
+      `\`turbo run build\` does not schedule ${taskId}`,
+      [
+        "CI's `pnpm build` is what produces dist/ before `changeset publish`.",
+        "If this task is not scheduled, mcp is published without a fresh bundle.",
+        `Fix by giving ${PKG_NAME} a \`build\` script, or restore the turbo task graph.`,
+      ].join("\n"),
+    );
+  }
+}
+
+/* ── run ─────────────────────────────────────────────────────────────────── */
+const pkg = readJson(path.join(PKG_DIR, "package.json"));
+
+checkWorkspaceDeps(pkg);
+checkBuildChain(pkg);
+checkTurboSchedule();
+
+for (const n of notes) console.warn(`! ${n}`);
+
+if (failures.length) {
+  console.error(
+    `\n✗ ${PKG_NAME} release wiring is broken (${failures.length} problem${failures.length > 1 ? "s" : ""}):\n`,
+  );
+  for (const { title, detail } of failures) {
+    console.error(`  ✗ ${title}`);
+    for (const line of detail.split("\n")) console.error(`    ${line}`);
+    console.error("");
+  }
+  console.error(
+    "See packages/mcp/아키텍쳐.md section 6 for why each of these matters.\n",
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✓ ${PKG_NAME} release wiring intact (workspace deps · build:package chain · turbo scheduling)`,
+);

--- a/packages/mcp/scripts/generate-metadata.cjs
+++ b/packages/mcp/scripts/generate-metadata.cjs
@@ -5,6 +5,17 @@
  * source, normalizes it, and writes a sibling `src/data/*.generated.json`. Running this as a build
  * step (see `build:package`) makes drift between the served metadata and the code impossible.
  *
+ * IMPORTANT — these paths point at monorepo WORKSPACE SOURCES (`../../base/src/...`), not at
+ * node_modules. That is deliberate: a change to base is picked up by the very next build, with no
+ * intermediate publish. The flip side is that this package is coupled to base's directory layout
+ * and file conventions; see 아키텍쳐.md §9 "깨지기 쉬운 지점" for the assumptions that, if broken,
+ * make a builder silently emit less data instead of failing.
+ *
+ * The generated JSON is COMMITTED. `build:package` regenerates it anyway, so the published bundle
+ * is always fresh — committing it is what makes the effect of a base change reviewable in a PR
+ * diff. CI enforces that the committed copy is current (build-test.yml → "MCP 메타데이터 최신 여부").
+ * After changing base, run `pnpm --filter @shoplflow/mcp generate:metadata` and commit the result.
+ *
  *   buildTokens()     <- packages/base/src/styles/tokens.json          -> tokens.generated.json
  *   buildIcons()      <- packages/{shopl,hada}-assets .../generated    -> icons.generated.json
  *   buildComponents() <- packages/base/src/components (each *.types.ts)   -> components.generated.json

--- a/packages/mcp/src/data/components.generated.json
+++ b/packages/mcp/src/data/components.generated.json
@@ -1,7 +1,7 @@
 {
   "source": "packages/base/src/components/**/*.types.ts",
   "importFrom": "@shoplflow/base",
-  "count": 63,
+  "count": 65,
   "withVariants": 19,
   "components": [
     {
@@ -554,12 +554,58 @@
       ]
     },
     {
+      "name": "Divider",
+      "group": "Divider",
+      "importFrom": "@shoplflow/base",
+      "polymorphic": true,
+      "nativeAttrs": "'div'",
+      "variants": [],
+      "props": [
+        {
+          "name": "color",
+          "optional": true,
+          "type": "CSSProperties['color']",
+          "description": "구분선의 색상을 설정합니다. CSS color 값을 그대로 사용합니다. (예: `colorTokens.neutral200`, `'#EAEAEA'`)"
+        },
+        {
+          "name": "direction",
+          "optional": true,
+          "type": "DividerDirection",
+          "description": "구분선의 방향을 설정합니다. (값: row, column)"
+        },
+        {
+          "name": "isFull",
+          "optional": true,
+          "type": "boolean",
+          "description": "true이면 direction 방향(length 축)으로 부모의 가용 영역을 가득 채웁니다. (`align-self: stretch` + length 축을 `auto`로 설정) 부모 padding 안쪽(content 영역)을 채우며, 부모 높이가 불확정이거나 `align-items`가 stretch가 아니어도 안정적으로 늘어납니다. 부모가 flex 컨테이너일 때 가장 잘 동작하며, `length`보다 우선합니다."
+        },
+        {
+          "name": "length",
+          "optional": true,
+          "type": "CSSProperties['width']",
+          "description": "구분선이 뻗어나가는 길이를 설정합니다. (direction이 row면 width, column이면 height에 적용)"
+        },
+        {
+          "name": "thickness",
+          "optional": true,
+          "type": "CSSProperties['width']",
+          "description": "구분선의 두께를 설정합니다. (direction이 row면 height, column이면 width에 적용)"
+        }
+      ]
+    },
+    {
       "name": "Dropdown",
       "group": "Dropdown",
       "importFrom": "@shoplflow/base",
       "polymorphic": false,
       "variants": [],
       "props": [
+        {
+          "name": "autoPlacement",
+          "optional": true,
+          "type": "AutoPlacementOptions",
+          "description": "화면 뷰에 따라 자동으로 위치를 조정합니다. `placement` 또는 `middlewares`가 지정되면 무시됩니다. Ref: https://floating-ui.com/docs/autoplacement"
+        },
         {
           "name": "disabled",
           "optional": true,
@@ -570,6 +616,12 @@
           "optional": true,
           "type": "boolean",
           "description": "외부에서 `isOpen`을 제어할 수 있습니다."
+        },
+        {
+          "name": "middlewares",
+          "optional": true,
+          "type": "Array<Middleware | null | undefined | false>",
+          "description": "floating ui의 middleware를 설정합니다. 지정 시 기본 `autoPlacement`는 적용되지 않습니다. Ref: https://floating-ui.com/docs/useFloating#middleware"
         },
         {
           "name": "offset",
@@ -591,6 +643,11 @@
           "name": "popper",
           "optional": true,
           "type": "ReactNode"
+        },
+        {
+          "name": "strategy",
+          "optional": true,
+          "type": "Strategy"
         },
         {
           "name": "trigger",
@@ -1598,6 +1655,11 @@
           "name": "data",
           "optional": false,
           "type": "Array<{ label: string; value: string }>"
+        },
+        {
+          "name": "middlewares",
+          "optional": true,
+          "type": "Array<Middleware | null | undefined | false>"
         },
         {
           "name": "pageSize",
@@ -2900,14 +2962,15 @@
       "variants": [],
       "props": [
         {
+          "name": "buttonLineClamp",
+          "optional": true,
+          "type": "number",
+          "description": "값이 있으면 각 InnerRadio의 라벨 텍스트를 해당 줄 수로 제한(line-clamp)하고, 넘치는 텍스트는 말줄임(…)으로 처리합니다. 너비가 제약되는 `fullWidth` 모드에서 가장 잘 동작합니다."
+        },
+        {
           "name": "disabled",
           "optional": true,
           "type": "boolean"
-        },
-        {
-          "name": "fixedWidth",
-          "optional": false,
-          "type": "number"
         },
         {
           "name": "onChange",
@@ -2955,6 +3018,14 @@
           "type": "boolean"
         }
       ]
+    },
+    {
+      "name": "ToggleButtonWidth",
+      "group": "ToggleButton",
+      "importFrom": "@shoplflow/base",
+      "polymorphic": false,
+      "variants": [],
+      "props": []
     },
     {
       "name": "Tooltip",

--- a/packages/mcp/src/data/icons.generated.json
+++ b/packages/mcp/src/data/icons.generated.json
@@ -7,9 +7,9 @@
     "shopl",
     "hada"
   ],
-  "count": 451,
+  "count": 473,
   "countByDomain": {
-    "shopl": 347,
+    "shopl": 369,
     "hada": 104
   },
   "icons": [
@@ -81,6 +81,16 @@
       "keywords": [
         "abnormal",
         "w"
+      ]
+    },
+    {
+      "name": "IcAddCircle",
+      "alias": "AddCircleIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "add",
+        "circle"
       ]
     },
     {
@@ -394,6 +404,16 @@
       ]
     },
     {
+      "name": "IcBookmarkFill",
+      "alias": "BookmarkFillIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "bookmark",
+        "fill"
+      ]
+    },
+    {
       "name": "IcBookmarkFilledMedium",
       "alias": "BookmarkFilledMediumIcon",
       "domain": "shopl",
@@ -415,12 +435,30 @@
       ]
     },
     {
+      "name": "IcBookmark",
+      "alias": "BookmarkIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "bookmark"
+      ]
+    },
+    {
       "name": "IcBox",
       "alias": "BoxIcon",
       "domain": "shopl",
       "importFrom": "@shoplflow/shopl-assets",
       "keywords": [
         "box"
+      ]
+    },
+    {
+      "name": "IcBrand",
+      "alias": "BrandIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "brand"
       ]
     },
     {
@@ -923,6 +961,26 @@
       ]
     },
     {
+      "name": "IcDragHorizontal",
+      "alias": "DragHorizontalIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "drag",
+        "horizontal"
+      ]
+    },
+    {
+      "name": "IcDragVertical",
+      "alias": "DragVerticalIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "drag",
+        "vertical"
+      ]
+    },
+    {
       "name": "IcDrag",
       "alias": "DragIcon",
       "domain": "shopl",
@@ -947,6 +1005,15 @@
       "importFrom": "@shoplflow/shopl-assets",
       "keywords": [
         "dropdown"
+      ]
+    },
+    {
+      "name": "IcDuration",
+      "alias": "DurationIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "duration"
       ]
     },
     {
@@ -1148,6 +1215,18 @@
       ]
     },
     {
+      "name": "IcFlexibleWorkingHoursSystem",
+      "alias": "FlexibleWorkingHoursSystemIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "flexible",
+        "working",
+        "hours",
+        "system"
+      ]
+    },
+    {
       "name": "IcFlexibleWorking",
       "alias": "FlexibleWorkingIcon",
       "domain": "shopl",
@@ -1155,6 +1234,15 @@
       "keywords": [
         "flexible",
         "working"
+      ]
+    },
+    {
+      "name": "IcFlexitime",
+      "alias": "FlexitimeIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "flexitime"
       ]
     },
     {
@@ -1511,6 +1599,15 @@
       "importFrom": "@shoplflow/shopl-assets",
       "keywords": [
         "graph"
+      ]
+    },
+    {
+      "name": "IcGrid",
+      "alias": "GridIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "grid"
       ]
     },
     {
@@ -1994,6 +2091,16 @@
       ]
     },
     {
+      "name": "IcInfoXsmall",
+      "alias": "InfoXsmallIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "info",
+        "xsmall"
+      ]
+    },
+    {
       "name": "IcInfo",
       "alias": "InfoIcon",
       "domain": "shopl",
@@ -2369,6 +2476,16 @@
       ]
     },
     {
+      "name": "IcMultiText",
+      "alias": "MultiTextIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "multi",
+        "text"
+      ]
+    },
+    {
       "name": "IcMultipleChoice",
       "alias": "MultipleChoiceIcon",
       "domain": "shopl",
@@ -2526,6 +2643,15 @@
       ]
     },
     {
+      "name": "IcPeriod",
+      "alias": "PeriodIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "period"
+      ]
+    },
+    {
       "name": "IcPhoneLine",
       "alias": "PhoneLineIcon",
       "domain": "shopl",
@@ -2562,6 +2688,16 @@
       "keywords": [
         "pin",
         "check"
+      ]
+    },
+    {
+      "name": "IcPinCluster",
+      "alias": "PinClusterIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "pin",
+        "cluster"
       ]
     },
     {
@@ -2660,6 +2796,16 @@
       ]
     },
     {
+      "name": "IcProcessingXsmall",
+      "alias": "ProcessingXsmallIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "processing",
+        "xsmall"
+      ]
+    },
+    {
       "name": "IcPush",
       "alias": "PushIcon",
       "domain": "shopl",
@@ -2684,6 +2830,16 @@
       "importFrom": "@shoplflow/shopl-assets",
       "keywords": [
         "quit"
+      ]
+    },
+    {
+      "name": "IcRactangleXsmall",
+      "alias": "RactangleXsmallIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "ractangle",
+        "xsmall"
       ]
     },
     {
@@ -2913,6 +3069,15 @@
       ]
     },
     {
+      "name": "IcSection",
+      "alias": "SectionIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "section"
+      ]
+    },
+    {
       "name": "IcSend",
       "alias": "SendIcon",
       "domain": "shopl",
@@ -2986,6 +3151,16 @@
       "importFrom": "@shoplflow/shopl-assets",
       "keywords": [
         "signature"
+      ]
+    },
+    {
+      "name": "IcSingleText",
+      "alias": "SingleTextIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "single",
+        "text"
       ]
     },
     {
@@ -3161,6 +3336,24 @@
       ]
     },
     {
+      "name": "IcTime",
+      "alias": "TimeIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "time"
+      ]
+    },
+    {
+      "name": "IcTitle",
+      "alias": "TitleIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "title"
+      ]
+    },
+    {
       "name": "IcTodoMedium",
       "alias": "TodoMediumIcon",
       "domain": "shopl",
@@ -3242,6 +3435,16 @@
       ]
     },
     {
+      "name": "IcUploadXsmall",
+      "alias": "UploadXsmallIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "upload",
+        "xsmall"
+      ]
+    },
+    {
       "name": "IcUserNameLine",
       "alias": "UserNameLineIcon",
       "domain": "shopl",
@@ -3310,6 +3513,16 @@
       "importFrom": "@shoplflow/shopl-assets",
       "keywords": [
         "waiting",
+        "medium"
+      ]
+    },
+    {
+      "name": "IcWebMedium",
+      "alias": "WebMediumIcon",
+      "domain": "shopl",
+      "importFrom": "@shoplflow/shopl-assets",
+      "keywords": [
+        "web",
         "medium"
       ]
     },

--- a/packages/mcp/src/data/stories.generated.json
+++ b/packages/mcp/src/data/stories.generated.json
@@ -1,8 +1,8 @@
 {
   "source": "packages/base/src/components (each *.stories.tsx)",
   "importFrom": "@shoplflow/base",
-  "count": 41,
-  "exampleCount": 142,
+  "count": 42,
+  "exampleCount": 149,
   "modules": [
     {
       "name": "AnnualDatepicker",
@@ -208,6 +208,36 @@
         {
           "story": "Range",
           "code": "<Stack width='400px'>\n      <DayDatepicker\n        calendarType={{\n          type: 'range',\n          handleDayRangeChange(dates) {\n            if (Array.isArray(dates)) {\n              const [start, end] = dates;\n              setStartDate(start);\n              setEndDate(end);\n            } else {\n              setStartDate(dates);\n            }\n          },\n        }}\n        selected={startDate ?? null}\n        startDate={startDate || undefined}\n        endDate={endDate || undefined}\n        sizeVar={'M'}\n        locale={ko}\n      />\n    </Stack>"
+        }
+      ]
+    },
+    {
+      "name": "Divider",
+      "group": "Divider",
+      "title": "COMPONENTS/Divider",
+      "importFrom": "@shoplflow/base",
+      "examples": [
+        {
+          "story": "Playground",
+          "code": "<ComponentStage>\n      {args.direction === 'column' ? (\n        <Stack.Horizontal height={'80px'} align={'stretch'} width={'fit-content'}>\n          <Text>왼쪽</Text>\n          <Divider {...args} data-testid={TEST_ID} />\n          <Text>오른쪽</Text>\n        </Stack.Horizontal>\n      ) : (\n        <Stack.Vertical width={'240px'} spacing={'spacing12'}>\n          <Text>위쪽</Text>\n          <Divider {...args} data-testid={TEST_ID} />\n          <Text>아래쪽</Text>\n        </Stack.Vertical>\n      )}\n    </ComponentStage>"
+        },
+        {
+          "story": "Row",
+          "args": "{ direction: 'row' }",
+          "code": "<ComponentStage>\n      <Stack.Vertical width={'240px'} spacing={'spacing12'}>\n        <Text>위쪽 콘텐츠</Text>\n        <Divider {...args} />\n        <Text>아래쪽 콘텐츠</Text>\n      </Stack.Vertical>\n    </ComponentStage>"
+        },
+        {
+          "story": "Column",
+          "args": "{ direction: 'column', length: '14px' }",
+          "code": "<ComponentStage>\n      <Stack.Horizontal align={'center'} spacing={'spacing12'} width={'fit-content'}>\n        <Text>왼쪽</Text>\n        <Divider {...args} />\n        <Text>가운데</Text>\n        <Divider {...args} />\n        <Text>오른쪽</Text>\n      </Stack.Horizontal>\n    </ComponentStage>"
+        },
+        {
+          "story": "IsFull",
+          "code": "<ComponentStage>\n      <Stack.Horizontal width={'320px'} height={'120px'} spacing={'spacing24'} align={'stretch'}>\n        <Stack.Vertical flex={'1'} spacing={'spacing12'} justify={'center'}>\n          <Text>위쪽 콘텐츠</Text>\n          <Divider direction={'row'} isFull />\n          <Text>아래쪽 콘텐츠</Text>\n        </Stack.Vertical>\n        <Divider direction={'column'} isFull />\n        <Stack.Vertical flex={'1'} justify={'center'}>\n          <Text>세로 구분선이 부모 높이를 가득 채웁니다.</Text>\n        </Stack.Vertical>\n      </Stack.Horizontal>\n    </ComponentStage>"
+        },
+        {
+          "story": "Colors",
+          "code": "<ComponentStage>\n      <Stack.Vertical width={'240px'} spacing={'spacing16'}>\n        <Divider color={colorTokens.neutral200} />\n        <Divider color={colorTokens.neutral300} />\n        <Divider color={colorTokens.primary300} thickness={'2px'} />\n        <Divider color={colorTokens.red300} thickness={'2px'} />\n      </Stack.Vertical>\n    </ComponentStage>"
         }
       ]
     },
@@ -899,6 +929,14 @@
         {
           "story": "ItemDisabled",
           "code": "<Stack>\n      <ToggleButton {...args} selectedValue={selectedValue} onChange={handleChange} targetName='item-disabled-group'>\n        <ToggleButton.InnerRadio value='value1' label='Toggle1' id='item-disabled-1' />\n        <ToggleButton.InnerRadio value='value2' label='Toggle2' id='item-disabled-2' disabled />\n        <ToggleButton.InnerRadio value='value3' label='Toggle3' id='item-disabled-3' />\n      </ToggleButton>\n    </Stack>"
+        },
+        {
+          "story": "FullWidth",
+          "code": "<Stack spacing='spacing16'>\n      <Text>fullWidth=true: 부모 너비를 100% 채우고 각 아이템이 동일 비율(flex:1)로 분배됩니다.</Text>\n\n      {/* 부모 너비를 제한해 100% 채움을 시각적으로 확인하기 위한 컨테이너 */}\n      <div style={{ width: 480, border: '1px dashed #ccc' }}>\n        <ToggleButton\n          {...args}\n          fullWidth\n          selectedValue={selectedValue}\n          onChange={handleChange}\n          targetName='full-width-group'\n        >\n          <ToggleButton.InnerRadio value='value1' label='Toggle1Toggle1Toggle1Toggle1' id='full-width-1' />\n          <ToggleButton.InnerRadio value='value2' label='Toggle2 Toggle2Toggle2Toggle2' id='full-width-2' />\n          <ToggleButton.InnerRadio value='value3' label='Toggle3' id='full-width-3' />\n        </ToggleButton>\n      </div>\n    </Stack>"
+        },
+        {
+          "story": "ButtonLineClamp",
+          "code": "<Stack spacing='spacing16'>\n      <Text>\n        buttonLineClamp: 라벨이 길어도 지정한 줄 수까지만 표시하고 말줄임(…) 처리합니다. (fullWidth와 함께 사용)\n      </Text>\n\n      <div style={{ width: 360, border: '1px dashed #ccc' }}>\n        <ToggleButton\n          {...args}\n          fullWidth\n          selectedValue={selectedValue}\n          onChange={handleChange}\n          targetName='line-clamp-group'\n        >\n          <ToggleButton.InnerRadio\n            value='value1'\n            label='아주 긴 라벨 텍스트 예시 첫번째 항목입니다'\n            id='line-clamp-1'\n          />\n          <ToggleButton.InnerRadio value='value2' label='두번째 항목도 라벨이 꽤 길어요' id='line-clamp-2' />\n          <ToggleButton.InnerRadio value='value3' label='짧은' id='line-clamp-3' />\n        </ToggleButton>\n      </div>\n    </Stack>"
         }
       ]
     },

--- a/packages/mcp/src/data/tokens.generated.json
+++ b/packages/mcp/src/data/tokens.generated.json
@@ -5,18 +5,18 @@
     "shopl",
     "hada"
   ],
-  "count": 113,
+  "count": 114,
   "countByType": {
     "color": 44,
     "borderRadius": 6,
     "fontWeights": 3,
     "spacing": 13,
     "boxShadow": 1,
-    "typography": 46
+    "typography": 47
   },
   "countByDomain": {
     "shared": 55,
-    "shopl": 29,
+    "shopl": 30,
     "hada": 29
   },
   "tokens": [
@@ -890,6 +890,20 @@
       "cssVar": "--primary400",
       "className": null,
       "value": "#2d89e4"
+    },
+    {
+      "name": "caption2_700",
+      "type": "typography",
+      "domain": "shopl",
+      "path": "caption2_700",
+      "cssVar": null,
+      "className": ".caption2_700",
+      "value": {
+        "fontWeight": "{fontWeight.bold}",
+        "fontSize": "10",
+        "lineHeight": "15",
+        "fontFamily": "Pretendard"
+      }
     },
     {
       "name": "heading1_700",

--- a/packages/mcp/아키텍쳐.md
+++ b/packages/mcp/아키텍쳐.md
@@ -1,0 +1,446 @@
+# @shoplflow/mcp 아키텍쳐
+
+> AI 코딩 에이전트에게 shoplflow 디자인 시스템을 노출하는 MCP(Model Context Protocol) 서버의 내부 구조 문서.
+> 사용법은 [README.md](./README.md)를 참고하세요. 이 문서는 **왜 이렇게 만들었는지 / 어디를 고쳐야 하는지**를 다룹니다.
+
+---
+
+## 1. 이 패키지가 푸는 문제
+
+에이전트(Claude Code, Cursor, Codex …)에게 "shoplflow로 UI 만들어줘"라고 하면, 학습 데이터에 없는 사내 디자인 시스템이므로 **토큰 이름·컴포넌트 prop·아이콘 이름을 지어냅니다.**
+
+```tsx
+// 에이전트가 흔히 만들어내는 코드 (전부 존재하지 않음)
+<Button variant="primary" size="medium" color="#3B82F6" />
+<Icon name="plus" />
+```
+
+MCP 서버는 **실제로 배포되는 라이브러리에서 추출한 메타데이터**를 툴로 노출해서, 에이전트가 추측 대신 조회하도록 만듭니다.
+
+```tsx
+// 조회 후 생성되는 코드
+<Button styleVar="PRIMARY" sizeVar="M" />
+<Icon iconSource={AddIcon} sizeVar="S" color="neutral500" />
+```
+
+---
+
+## 2. 핵심 설계 원칙
+
+| 원칙                                  | 구현                                                                                                             | 이유                                                                                        |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| **드리프트 구조적 차단**              | 메타데이터를 손으로 쓰지 않고 **빌드 타임에 라이브러리 소스에서 추출**                                           | 손으로 관리하면 반드시 실제 코드와 어긋남. 추출이면 어긋날 수가 없음                        |
+| **단일 출처(Single Source of Truth)** | 배포되는 라이브러리를 만드는 **바로 그 파일들**을 읽음 (`tokens.json`, `*.types.ts`, `*.stories.tsx`, 에셋 배럴) | 별도 문서/스키마를 두면 그것 자체가 또 하나의 드리프트 지점                                 |
+| **런타임 얇게**                       | 서버는 필터·스코어링만 수행. 파싱/AST 분석은 전부 빌드 타임                                                      | 툴 호출 지연 최소화, 런타임 의존성 최소화(`@modelcontextprotocol/sdk` + `zod`뿐)            |
+| **파일 조회 없는 단일 바이너리**      | tsup의 `loader: { '.json': 'json' }`로 데이터를 **번들에 인라인**                                                | `npx -y @shoplflow/mcp` 한 줄로 동작. 경로 해석 실패·누락 파일 이슈 없음                    |
+| **큐레이션은 딱 한 파일**             | 사람이 판단해야 하는 내용만 `setup.curated.json`에 격리                                                          | 팀이 어디를 고쳐야 하는지 명확. 나머지는 건드릴 필요가 없음                                 |
+| **생성 결과물을 커밋**                | `src/data/*.generated.json`을 git에 추적                                                                         | 재현 가능한 배포 + PR diff에서 "라이브러리 변경이 메타데이터에 어떻게 반영됐는지" 리뷰 가능 |
+
+---
+
+## 3. 전체 구조
+
+```mermaid
+flowchart LR
+  subgraph SRC["① 소스 (배포 라이브러리의 실제 파일)"]
+    T["base/src/styles/tokens.json"]
+    A["{shopl,hada}-assets<br/>icons/generated/index.ts"]
+    C["base/src/components/**/*.types.ts"]
+    S["base/src/components/**/*.stories.tsx"]
+    P["base/package.json<br/>ShoplflowProvider.tsx<br/>Domain.ts"]
+    K["setup.curated.json<br/>(팀이 직접 관리)"]
+  end
+
+  subgraph GEN["② 생성 (빌드 타임 / Node CJS)"]
+    G["generate-metadata.cjs<br/>· buildTokens<br/>· buildIcons"]
+    EC["extract-components.cjs<br/>(ts-morph)"]
+    ES["extract-stories.cjs<br/>(ts-morph)"]
+    EU["extract-setup.cjs<br/>(regex + package.json)"]
+  end
+
+  subgraph DATA["③ 데이터 (커밋됨)"]
+    D["src/data/*.generated.json<br/>tokens · icons · components · stories · setup"]
+  end
+
+  subgraph SRV["④ 서버 (런타임)"]
+    V["src/server.ts<br/>8 tools + 2 resources"]
+    I["src/index.ts<br/>stdio transport"]
+  end
+
+  subgraph OUT["⑤ 배포"]
+    B["dist/index.js<br/>(bin: shoplflow-mcp)"]
+  end
+
+  T --> G
+  A --> G
+  C --> EC
+  S --> ES
+  P --> EU
+  K --> EU
+  EC --> G
+  ES --> G
+  EU --> G
+  G --> D
+  D -->|tsup 인라인 번들| B
+  V --> I --> B
+  B <-->|stdio / JSON-RPC| AGENT["AI 에이전트"]
+```
+
+### 디렉터리 맵
+
+```
+packages/mcp/
+├── setup.curated.json          ★ 팀이 직접 관리하는 유일한 파일
+├── scripts/
+│   ├── generate-metadata.cjs   오케스트레이터 + 토큰/아이콘 빌더
+│   ├── extract-components.cjs  Phase 3 · ts-morph로 *.types.ts → API 카드
+│   ├── extract-stories.cjs     Phase 4 · ts-morph로 *.stories.tsx → 사용 예제
+│   ├── extract-setup.cjs       Phase 5 · AUTO(코드) + CURATED(사람) 병합
+│   ├── check-release-wiring.cjs  릴리즈 연동 3대 불변식 검증 (CI + 로컬)
+│   └── smoke.mjs               실제 MCP 클라이언트로 dist 서버 검증
+├── src/
+│   ├── data/*.generated.json   ← 생성물 (커밋 대상, 직접 편집 금지)
+│   ├── server.ts               툴·리소스 등록 + 검색 스코어링
+│   └── index.ts                stdio 부트스트랩
+└── tsup.config.ts              ESM · node18 · JSON 인라인 · shebang
+```
+
+---
+
+## 4. 레이어별 상세
+
+### ① 소스 레이어 — 무엇을 읽는가
+
+| 소스                                                        | 읽는 주체                | 산출물                                | 읽는 방식                             |
+| ----------------------------------------------------------- | ------------------------ | ------------------------------------- | ------------------------------------- |
+| `base/src/styles/tokens.json`                               | `buildTokens()`          | `tokens.generated.json`               | Tokens Studio 익스포트 JSON 트리 순회 |
+| `{shopl,hada}-assets/src/icons/generated/index.ts`          | `buildIcons()`           | `icons.generated.json`                | `export { … }` 블록 정규식 파싱       |
+| `base/src/components/**/*.types.ts`                         | `extract-components.cjs` | `components.generated.json`           | ts-morph AST (타입체커 미사용)        |
+| `base/src/components/**/*.stories.tsx`                      | `extract-stories.cjs`    | `stories.generated.json`              | ts-morph AST                          |
+| `base/package.json` · `ShoplflowProvider.tsx` · `Domain.ts` | `extract-setup.cjs`      | `setup.generated.json` (AUTO 파트)    | 정규식 + `exports` 필드               |
+| `setup.curated.json`                                        | `extract-setup.cjs`      | `setup.generated.json` (CURATED 파트) | 그대로 병합                           |
+
+> **모노레포 상대 경로로 직접 읽습니다** (`../../base/src/...`). `node_modules`가 아니라 워크스페이스 소스를 가리키므로, base 소스가 바뀌면 다음 추출에서 즉시 반영됩니다. 워크스페이스 의존성(`@shoplflow/base` 등)이 `devDependencies`에 선언된 이유는 런타임 사용이 아니라 **빌드 순서 보장 + 릴리즈 연동**입니다 — 아래 6절 참고.
+
+### ② 생성 레이어 — 5개의 빌더
+
+`generate-metadata.cjs`가 오케스트레이터입니다. 토큰·아이콘은 로직이 짧아 이 파일 안에 있고, AST가 필요한 3개는 별도 모듈로 분리했습니다.
+
+#### `buildTokens()` — 토큰
+
+`packages/base/scripts/seperate-tokens.cjs`(라이브러리 본체의 토큰 생성기)와 **같은 규칙**으로 트리를 나눕니다.
+
+- `shoplflow` 루트 → `shared` 도메인 (팔레트·spacing·radius·fontWeight·shadow)
+- `shopl` / `hada` → 브랜드별 타이포그래피 + primary/semantic 컬러
+- `$themes` / `$metadata` → 무시
+
+타입별로 **소비 방식이 다르다는 점**이 레코드에 인코딩됩니다:
+
+| `type`                     | 값 처리                                                   | 노출 필드                                                                      |
+| -------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `color`                    | `{group.name}` 별칭을 실제 리터럴로 해석 (`resolveColor`) | `cssVar: --{name}`                                                             |
+| `spacing` / `borderRadius` | 숫자 → `"16px"`                                           | `cssVar` (radius는 kebab-case)                                                 |
+| `fontWeights`              | 문자열화                                                  | `cssVar: --font-weight-{name}`                                                 |
+| `typography`               | 객체 그대로                                               | **`className: .{name}`** — CSS 변수가 아니라 클래스/`typography` prop으로 소비 |
+| `boxShadow` / `dropShadow` | `x y blur spread color` 문자열로 평탄화                   | —                                                                              |
+
+> 타이포그래피만 `cssVar`가 아니라 `className`인 이유: 라이브러리에서 `<Text typography="body1_700" />` 형태로 쓰기 때문입니다. 이 구분이 없으면 에이전트가 `var(--body1_700)` 같은 존재하지 않는 CSS를 씁니다.
+
+현재 산출: **114개** (color 44 · typography 47 · spacing 13 · borderRadius 6 · fontWeights 3 · boxShadow 1 / shared 55 · shopl 30 · hada 29)
+
+#### `buildIcons()` — 아이콘
+
+에셋 패키지의 배럴 파일이 공개 아이콘 이름의 출처입니다.
+
+```ts
+export { IcAdd as AddIcon, IcInfo as InfoIcon, … };
+//        ^raw name  ^public alias  — 둘 다 import 가능하므로 둘 다 노출
+```
+
+이름을 단어로 쪼개 검색 키워드를 만듭니다: `IcAiChatBot` → `["ai", "chat", "bot"]` (`Ic` 접두사 제거 후 camelCase 분해).
+
+현재 산출: **473개** (shopl 369 · hada 104). **브랜드마다 아이콘 세트가 다르므로** `domain` 필터가 중요합니다.
+
+#### `extract-components.cjs` — 컴포넌트 API (가장 복잡)
+
+라이브러리는 `utils/type/ComponentProps.ts`의 mixin을 조합해 props를 만듭니다. 추출기는 이 조합 규칙을 재현합니다.
+
+```
+1. mixin 파일을 한 번 파싱 → registry (인터페이스명 → props + JSDoc)
+2. 각 export된 `*Props`에 대해 intersection / heritage를 전개
+3. SizeVariantProps<T> / StyleVariantProps<T> / IconSizeVariantProps<T>를
+   그 T를 만들어내는 `as const` 객체에 연결 → 정확한 variant 값 확보
+4. 다형성(`as`) · 네이티브 HTML 속성 전달 여부를 플래그로 표시
+```
+
+핵심은 **`expandRef()` 단일 디스패처**입니다. 인터페이스의 `extends`와 타입 별칭의 `&`가 같은 경로로 처리되므로 두 문법이 동일하게 해석됩니다.
+
+| 참조 이름                                                         | 처리                                                                      |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `SizeVariantProps` / `StyleVariantProps` / `IconSizeVariantProps` | variant로 등록 + 타입 인자를 `as const` enum까지 추적해 실제 값 배열 확보 |
+| `PolymorphicComponentProps` / `RenderConfigProps` / `AsProp`      | `polymorphic: true` (+ 2번째 타입 인자 재귀 전개)                         |
+| `HTMLAttributes`, `ComponentPropsWithoutRef` 등 8종               | `nativeAttrs` 플래그 — prop을 나열하지 않음 (수백 개가 되어 무의미)       |
+| `Omit<X, …>`                                                      | X를 전개 (제외 목록은 무시)                                               |
+| registry에 있는 mixin                                             | props 병합                                                                |
+| 같은 파일의 로컬 인터페이스/별칭                                  | 재귀 전개 (`seen` 셋으로 순환 차단)                                       |
+
+필터: `*Props`로 끝나되 `*OptionProps` / `*GenericProps` / `*StyledProps`는 제외 (내부 빌딩 블록).
+
+> **타입체커를 쓰지 않습니다.** AST만 읽으므로 빠르고, `base`가 컴파일 가능한 상태가 아니어도 동작합니다. 대가로 복잡한 조건부 타입은 원문 텍스트로만 노출되며 80자에서 잘립니다(`MAX_TYPE_LEN`).
+
+현재 산출: **65개 카드 / 43개 모듈**, 그중 19개가 variant 보유. 복합 컴포넌트는 파트 단위로 분리됩니다 (`ModalContainer`, `ModalHeader`, …).
+
+#### `extract-stories.cjs` — 사용 예제
+
+스토리는 "실제로 동작하는 사용법"의 최고 출처입니다. 신호는 남기고 테스트 노이즈는 버립니다.
+
+| 스토리 필드                        | 처리                                     |
+| ---------------------------------- | ---------------------------------------- |
+| `args`                             | 유지 (현실적인 prop 조합) — 600자 클립   |
+| `render`                           | 유지 — 반환 JSX만 추출, 1200자 클립      |
+| 함수형 스토리(CSF2)                | 함수 본문의 `return` 표현식 추출         |
+| `play` / `parameters` / `argTypes` | **버림** (인터랙션 테스트·스토리북 설정) |
+
+모듈당 최대 8개(`MAX_EXAMPLES`). `satisfies` / `as` / 괄호 래퍼는 `unwrap()`으로 벗겨 실제 표현식에 도달합니다.
+
+현재 산출: **42개 모듈 / 149개 예제**.
+
+#### `extract-setup.cjs` — 셋업 & 환경 (AUTO + CURATED)
+
+이 빌더만 **두 종류의 출처를 병합**합니다.
+
+```
+AUTO (코드에서 추출 → 절대 드리프트 없음)
+  provider 이름 / domain 기본값 / DomainType 값들   ← ShoplflowProvider.tsx, Domain.ts
+  CSS import 스펙파이어                              ← base/package.json exports 중 *.css
+  peerDependencies                                   ← base/package.json
+  client-only 사유                                   ← provider의 import 문에서 유도
+                                                       (framer-motion / Portal / useDomain / Emotion)
+  snippet                                            ← 위 사실들로 합성 ⇒ 잘못된 import를 쓸 수 없음
+CURATED (setup.curated.json — 사람의 판단)
+  setupSteps / environments(프레임워크별 지원 상태·워크어라운드) / instructions
+```
+
+> **snippet을 합성하는 이유**: 예제를 손으로 쓰면 import 경로나 prop이 실제와 어긋날 수 있습니다. 추출한 사실로 조립하면 구조적으로 불가능합니다.
+
+### ③ 데이터 레이어 — 스키마
+
+모든 파일은 `{ source, count, …통계, <배열> }` 형태입니다. `source` 필드는 "이 데이터가 어디서 왔는지"를 기록해 디버깅 시 소스를 되짚을 수 있게 합니다.
+
+```ts
+TokenRecord   { name, type, domain, path, value, cssVar, className }
+IconRecord    { name, alias, domain, importFrom, keywords[] }
+ComponentCard { name, group, importFrom, polymorphic, defaultElement?, nativeAttrs?,
+                variants: [{ prop, values[] }], props: [{ name, optional, type, description? }] }
+StoryModule   { name, group, title?, importFrom, examples: [{ story, args?, code? }] }
+Setup         { provider, styles[], peerDependencies, setupSteps[], snippet,
+                environments[], instructions }
+```
+
+### ④ 서버 레이어 — 8 툴 · 2 리소스
+
+`createServer()`가 전부를 등록합니다. 상태가 없으므로 인스턴스는 언제든 새로 만들 수 있습니다(테스트 용이).
+
+```
+instructions (연결 시 항상 노출)   ← setup.instructions
+  └ "Provider + global CSS 없이는 아무것도 렌더하지 마라 / client-only다"
+
+리소스  shoplflow://tokens       전체 토큰 카탈로그 JSON
+        shoplflow://components   컴포넌트 컴팩트 인덱스
+
+툴  탐색형(넓게)          →  상세형(좁게)
+    list_tokens          →  get_token
+    search_icon
+    search_component     →  get_component_api  →  get_usage_example
+    get_setup_guide / check_environment
+```
+
+**툴 설계 규칙 — "탐색 → 상세" 2단계.** 목록 툴은 요약(`summarize()`)만 반환하고 상세는 별도 툴로 분리했습니다. 65개 컴포넌트의 전체 prop을 한 번에 반환하면 에이전트 컨텍스트를 수만 토큰 잡아먹습니다.
+
+**미스 시 제안(suggestion) 규칙.** `get_token` / `get_component_api` / `get_usage_example`은 못 찾으면 에러 대신 `{ found: false, suggestions: [...] }`를 반환합니다. 에이전트가 오타를 스스로 교정하고 재시도할 수 있게 하기 위함입니다.
+
+**검색 스코어링 — AND 시맨틱.**
+
+```js
+// 모든 검색어가 점수에 기여해야 함. 하나라도 0이면 전체 0.
+for (const term of terms) {
+  const s = score(item, term);
+  if (s === 0) return 0;
+  total += s;
+}
+```
+
+다중 단어 질의가 결과를 **넓히는 게 아니라 좁히도록** 만드는 장치입니다. `"chat bot"`은 chat 관련 전부가 아니라 둘 다 만족하는 아이콘만 반환합니다.
+
+|              | 정확 일치      | 키워드 일치 | 부분 문자열        | 그 외                  |
+| ------------ | -------------- | ----------- | ------------------ | ---------------------- |
+| **아이콘**   | name/alias 100 | keyword 80  | name/alias 60      | keyword 부분일치 40    |
+| **컴포넌트** | name 100       | —           | name 60 · group 40 | prop명 30 · variant 20 |
+
+### ⑤ 배포 레이어
+
+```
+tsup: entry=src/index.ts · format=esm · target=node18 · platform=node
+      loader={'.json':'json'}  ← 데이터를 번들에 인라인
+      banner='#!/usr/bin/env node' · dts=false
+→ dist/index.js  (package.json bin: shoplflow-mcp)
+```
+
+`files: ["dist"]`이므로 npm에는 번들 하나만 올라갑니다. 소비자는 `npx -y @shoplflow/mcp`로 즉시 실행합니다.
+
+---
+
+## 5. 요청 흐름
+
+```
+에이전트 시작
+  └ MCP 클라이언트가 stdio로 프로세스 spawn (npx -y @shoplflow/mcp)
+      └ initialize → 서버가 instructions 반환
+          └ 클라이언트가 시스템 프롬프트에 주입 ("Provider/CSS 먼저!")
+
+사용자: "shoplflow로 삭제 버튼 만들어줘"
+  ├ search_component("button")        → Button, IconButton, SplitButton …
+  ├ get_component_api("Button")       → styleVar: [PRIMARY|SECONDARY|SOLID|GHOST]
+  │                                     sizeVar: [S|M|XS], polymorphic, props+JSDoc
+  ├ get_usage_example("Button")       → 실제 스토리 기반 JSX
+  ├ search_icon("trash")              → IcTrash / TrashIcon, importFrom
+  └ list_tokens({type:"color"})       → 정확한 토큰 키
+→ 환각 없는 코드 생성
+```
+
+> `index.ts`의 로그가 `console.error`인 것은 필수입니다. **stdout은 JSON-RPC 전용**이므로 `console.log`를 쓰면 프로토콜이 깨집니다.
+
+---
+
+## 6. base 릴리즈와의 연동 (가장 중요하고, 가장 안 보이는 부분)
+
+**"base가 릴리즈되면 mcp도 최신 메타데이터로 자동 재배포된다"**는 동작은 어느 한 곳에 선언돼 있지 않습니다. 서로 다른 5개 설정이 맞물려 만들어집니다.
+
+```
+base/src 수정
+  └ ① 추출기가 그 경로를 직접 읽음         scripts/*.cjs 의 "../../base/src/..." 상대경로
+      └ ② 빌드마다 무조건 재추출           package.json: "build:package": "pnpm generate:metadata && … && tsup"
+          └ ③ turbo가 스케줄 + 순서 보장   turbo.json: build:package.dependsOn = ["^build:package", …]
+              └ ④ changesets가 mcp 범프    mcp devDependencies(workspace:*) + .changeset/config.json
+                  │                          "updateInternalDependents": "always"
+                  └ ⑤ CI가 순서대로 실행    changesets-workflow.yml: pnpm build → version → publish
+```
+
+### ④가 가장 취약합니다
+
+`@shoplflow/base`는 mcp 런타임에 전혀 쓰이지 않습니다. 그래서 "안 쓰는데 왜 devDependencies에 있지?" 하고 지우기 쉽습니다. 지우면:
+
+- 추출은 상대경로라 **계속 정상 동작**하고
+- 빌드도 통과하고
+- 다만 **changesets가 mcp를 dependent로 인식하지 못해 버전 범프가 멈춥니다**
+
+결과적으로 base가 아무리 바뀌어도 새 mcp가 npm에 올라가지 않고, 소비자는 낡은 메타데이터를 계속 받습니다. **에러가 전혀 나지 않는 조용한 실패**입니다.
+
+실증: `CHANGELOG.md`의 `0.1.1`은 base의 ToggleButton 변경(#819)을 그대로 달고 배포됐습니다 — mcp 코드는 한 줄도 안 바뀐 릴리즈입니다.
+
+### ③도 명시적이지 않습니다
+
+mcp에는 `build` 스크립트가 **없고** `build:package`만 있습니다. 그런데도 루트 `pnpm build`(= `turbo run build`)가 mcp를 빌드합니다 — turbo가 turbo.json의 태스크를 전 패키지에 걸쳐 그래프로 펼치기 때문입니다. 읽어서는 알기 어려운 동작이라 `turbo.json`에 주석을 달아뒀습니다.
+
+### 이 3개를 CI가 검증합니다
+
+`scripts/check-release-wiring.cjs`가 위 불변식을 실행 가능한 형태로 고정합니다.
+
+```bash
+pnpm --filter @shoplflow/mcp check:wiring
+```
+
+| 검사                      | 깨지면 생기는 일                                             |
+| ------------------------- | ------------------------------------------------------------ |
+| 워크스페이스 devDeps 존재 | changesets가 mcp를 범프하지 않아 재배포가 멈춤 (조용한 실패) |
+| `build:package` 체인      | 스테일 메타데이터로 배포됨                                   |
+| turbo가 mcp를 스케줄      | `pnpm build`가 mcp의 dist를 만들지 않음                      |
+
+여기에 더해 `build-test.yml`이 `pnpm build` 직후 `git diff --exit-code packages/mcp/src/data/`로 **커밋된 메타데이터가 최신인지** 확인합니다. 이게 없으면 "생성물을 커밋해서 PR에서 리뷰 가능하게 한다"는 설계 의도가 조용히 무너집니다. (실제로 이 검증을 추가하던 시점에 이미 토큰 1개·아이콘 22개·컴포넌트 2개만큼 밀려 있었습니다.)
+
+---
+
+## 7. 확장 가이드
+
+### 새 툴 추가
+
+1. 데이터가 이미 있으면 `src/server.ts`에 `server.registerTool(...)`만 추가.
+2. 새 데이터가 필요하면 → 아래 "새 데이터 소스 추가".
+3. `description`은 **에이전트가 읽는 유일한 단서**입니다. "언제 호출해야 하는지"를 명시하세요 (기존 툴들의 서술 톤 참고).
+4. `inputSchema`는 zod. 모든 필드에 `.describe()`를 답니다.
+5. `scripts/smoke.mjs`에 호출 케이스 추가.
+
+### 새 데이터 소스 추가
+
+1. `scripts/extract-<name>.cjs`에 `build<Name>()`를 만들고 `module.exports`.
+2. `generate-metadata.cjs`에서 import → `writeJson('<name>.generated.json', ...)` → 콘솔 요약 한 줄 추가.
+3. `src/server.ts`에서 import (tsup가 자동 인라인).
+4. 타입 인터페이스를 `server.ts` 상단에 선언.
+5. `pnpm --filter @shoplflow/mcp generate:metadata` 실행 후 **생성된 JSON을 커밋** (안 하면 CI가 막습니다).
+
+### 셋업 가이드 문구 수정
+
+`setup.curated.json`만 고칩니다. 특히 `environments`의 Next.js 항목은 라이브러리의 실제 지원 입장과 맞는지 팀이 검증해야 합니다(현재 `verify` 필드에 미검증 표시됨).
+
+---
+
+## 8. 설계 결정 & 트레이드오프
+
+| 결정                      | 대안                        | 선택 이유                                                                                   |
+| ------------------------- | --------------------------- | ------------------------------------------------------------------------------------------- |
+| 빌드 타임 추출 + 커밋     | 런타임에 소스 파싱          | 소비자 머신에 모노레포가 없음. 번들 인라인이어야 `npx` 한 줄로 동작                         |
+| ts-morph AST (타입체커 X) | TS 컴파일러 API 풀 타입체크 | 속도(수십 배) + `base`의 컴파일 상태와 무관하게 동작. 대가: 복잡한 조건부 타입은 텍스트로만 |
+| 스토리에서 예제 추출      | 예제를 손으로 작성          | 스토리는 CI에서 렌더되므로 항상 동작이 검증됨. 손으로 쓴 예제는 썩음                        |
+| stdio 전송                | HTTP/SSE                    | 로컬 에디터 에이전트가 표준으로 쓰는 방식. 인증·네트워크 불필요                             |
+| 목록/상세 툴 분리         | 단일 만능 툴                | 컨텍스트 예산 보호. 에이전트가 필요한 만큼만 가져감                                         |
+| AND 스코어링              | OR 스코어링                 | 다중 단어 질의에서 노이즈 폭발 방지                                                         |
+| 미스 시 suggestion        | 에러 반환                   | 에이전트의 자가 교정 루프를 가능하게 함                                                     |
+
+---
+
+## 9. 유지보수 체크리스트
+
+### 언제 재생성이 필요한가
+
+`build:package`가 항상 `generate:metadata`를 먼저 돌리므로 배포물은 자동으로 최신입니다. 다만 **커밋된 JSON**은 사람이 갱신해야 하고, PR CI가 이를 강제합니다.
+
+| 변경                                                 | 영향                        |
+| ---------------------------------------------------- | --------------------------- |
+| `tokens.json` 수정                                   | `tokens.generated.json`     |
+| SVG 아이콘 추가/삭제 (`build:assets` 후)             | `icons.generated.json`      |
+| `*.types.ts` 수정                                    | `components.generated.json` |
+| `*.stories.tsx` 수정                                 | `stories.generated.json`    |
+| provider / `base` package.json exports·peerDeps 수정 | `setup.generated.json`      |
+
+갱신 방법:
+
+```bash
+pnpm --filter @shoplflow/mcp generate:metadata
+git add packages/mcp/src/data
+```
+
+### 깨지기 쉬운 지점 (정규식·규약 의존)
+
+| 위치                     | 가정                                                      | 깨지면                             |
+| ------------------------ | --------------------------------------------------------- | ---------------------------------- |
+| `buildIcons()`           | 배럴이 `export { X as Y, … };` 한 블록                    | 아이콘 0개 (조용히 실패)           |
+| `extract-setup.cjs`      | provider가 `const Name =` 형태, `domain = 'SHOPL'` 기본값 | 폴백 문자열로 대체 (조용히 부정확) |
+| `extract-setup.cjs`      | `Domain.ts`의 유니온이 작은따옴표 리터럴                  | `domainValues` 빈 배열             |
+| `extract-components.cjs` | variant 타입이 `typeof <ConstObject>` 경유                | 해당 variant 값 누락               |
+| `extract-components.cjs` | mixin이 `utils/type/ComponentProps.ts`에 존재             | 해당 props 누락                    |
+
+→ 재생성 후 콘솔 요약(`✓ tokens: 114 …`)의 **개수가 급감하지 않았는지** 확인하는 것이 가장 싼 회귀 탐지입니다.
+
+### 알려진 갭
+
+- `server.ts`의 `new McpServer({ name, version: '0.0.0' })`가 하드코딩입니다 — `package.json`의 실제 버전과 무관합니다. 클라이언트에 표시되는 버전 정보가 부정확합니다.
+- `type-check` 스크립트가 `tsc --noEmit || true`라 **항상 통과**합니다. 타입 에러가 CI를 막지 않습니다.
+- 자동 테스트가 없습니다. `scripts/smoke.mjs`가 유일한 동작 검증이며 수동 실행입니다(`node scripts/smoke.mjs`, 빌드 후).
+
+---
+
+## 10. 관련 문서
+
+- [README.md](./README.md) — 설치·연결·툴 레퍼런스
+- [../skills/아키텍쳐.md](../skills/아키텍쳐.md) — 이 서버를 함께 배포하는 스킬/플러그인 패키지
+- [../../CLAUDE.md](../../CLAUDE.md) — 모노레포 전체 가이드

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -1,81 +1,133 @@
 # @shoplflow agent skills + plugin
 
-Downloadable AI-agent **skills** — plus an optional bundled **MCP server** — for developers who consume the `@shoplflow/*` packages in their own apps. They teach an AI coding assistant how to install, theme, and use the Shoplflow design system correctly — accurate import paths, the `styleVar`/`sizeVar` patterns, design tokens, brand theming, icons, and utils hooks.
+Downloadable AI-agent **skills** — plus an optional bundled **MCP server** — for developers who consume the
+`@shoplflow/*` packages in their own apps. They teach an AI coding assistant how to install, theme, and use the
+Shoplflow design system correctly: accurate import paths, the `styleVar`/`sizeVar` patterns, design tokens,
+brand theming, icons, and utils hooks.
 
-Works with **Claude Code**, **OpenAI Codex**, and **Cursor**.
+Works with **Claude Code**, **Cursor**, and **OpenAI Codex**.
 
-## What's inside
+> 내부 구조·설계 결정·확장 가이드는 [아키텍쳐.md](./아키텍쳐.md)를 참고하세요.
 
-| Skill                     | Covers                                                                               |
-| ------------------------- | ------------------------------------------------------------------------------------ |
-| `shoplflow-setup`         | Install, peer deps, required global CSS, `ShoplflowProvider`, SHOPL/HADA domain      |
-| `shoplflow-components`    | `Button`, `Text`, `Stack`, `Icon`, overlays; `styleVar`/`sizeVar`; polymorphic `as`  |
-| `shoplflow-theming`       | `colorTokens`/`spacingTokens`/`typographyTokens`…; token KEY vs VALUE; `getDomain()` |
-| `shoplflow-icons-utils`   | `@shoplflow/shopl-assets` / `hada-assets` icons + `@shoplflow/utils` hooks           |
-| `shoplflow-skills-update` | Check whether the installed skills are the latest version and update them            |
-
-The source of truth is `skills/<name>/SKILL.md` (the SKILL.md open standard). Claude Code, Cursor, and Codex all read this format, so the same files back both install paths below.
-
-## Two ways to install
-
-Pick **one**:
-
-- **A — As a plugin (recommended):** installs the skills **and** wires up the `@shoplflow/mcp` server in a single step, and your agent keeps both up to date through its own plugin-update flow. Needs a plugin-capable agent version (Claude Code, Cursor, or Codex).
-- **B — Skills only via `npx`:** the original installer. Vendors just the skill files into your repo (no MCP). Use it if you don't want the MCP server, or your agent predates plugin support.
-
-Both paths ship the **same** `skills/` files — A additionally configures MCP.
+**Contents:** [What's inside](#whats-inside) · [Which install path](#which-install-path) · [A. Plugin](#a-as-a-plugin--skills--mcp-in-one-step) · [B. npx](#b-skills-only-via-npx-no-mcp) · [Verify](#verify-the-install) · [Using them](#using-the-skills) · [Updating](#updating--uninstalling) · [Maintainers](#for-maintainers)
 
 ---
 
-### A. As a plugin — skills + MCP in one step
+## What's inside
 
-The plugin pulls the skills from this repo and declares the MCP server as `npx -y @shoplflow/mcp`, so you never hand-edit an MCP config. Updating the plugin (via your agent) refreshes both the skills and the MCP wiring.
+Five skills. Each is a single `SKILL.md` — YAML frontmatter (`name`, `description`) plus a markdown body.
 
-**Claude Code**
+| Skill                         | Covers                                                                                                                                                                                                                           | Loads when you…                                                                                   |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **`shoplflow-setup`**         | Install + peer deps, the required `@shoplflow/base/styles` import, `ShoplflowProvider`, SHOPL/HADA domain, common gotchas                                                                                                        | set up shoplflow, hit "styles aren't applying", or "Modal/Tooltip doesn't open"                   |
+| **`shoplflow-components`**    | `Button`, `Text`, `Stack`, `Icon`, overlays; the `styleVar`/`sizeVar` convention; polymorphic `as`; `lineClamp`; ref forwarding; full export catalog                                                                             | render or compose components, pick a variant, lay out with `Stack`, wire a Modal/Tooltip/Dropdown |
+| **`shoplflow-theming`**       | `colorTokens`/`spacingTokens`/`typographyTokens`/`borderRadiusTokens`/`boxShadowTokens`/`fontWeightTokens`; **token KEY vs VALUE**; typography-as-class; `getDomain()` brand branching                                           | style custom emotion components to match shoplflow, pick a token, branch per brand                |
+| **`shoplflow-icons-utils`**   | `@shoplflow/shopl-assets` / `hada-assets` icons + illustrations, rendering through `Icon`; `@shoplflow/utils` hooks (`useOutsideClick`, `useResizeObserver`, `useSelect`, `useMergeRefs`, `usePopover`, `useParentElementClick`) | render an icon, find an icon name, wire outside-click/popover/resize behaviour                    |
+| **`shoplflow-skills-update`** | Compare the installed skill version against npm and update                                                                                                                                                                       | ask "are the shoplflow skills up to date?"                                                        |
+
+**How loading works.** Agents don't read every skill on every turn. They keep `name` + `description` in
+context and pull the body only when a task matches — so the descriptions are written as _trigger specs_
+listing concrete situations, including symptoms ("broken Modal/Tooltip/Popper portals") rather than causes.
+
+The source of truth is `skills/<name>/SKILL.md` (the SKILL.md open standard). Claude Code, Cursor, and Codex
+all read this format, so the same files back both install paths below.
+
+### Skills vs the MCP server
+
+They solve different halves of the same problem — install both if you can.
+
+|            | Skills (this package)                                             | [`@shoplflow/mcp`](../mcp)                                               |
+| ---------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Provides   | **Idioms** — setup order, conventions, pitfalls, what to use when | **Facts** — 114 tokens, 65 component APIs, 473 icons, 149 story examples |
+| Delivery   | Static text injected into the prompt                              | Live tool calls                                                          |
+| Without it | Missing provider, wrong patterns, "why isn't this rendering"      | Hallucinated token names and props                                       |
+
+---
+
+## Which install path
+
+|                     | **A — Plugin** (recommended)            | **B — npx**                 |
+| ------------------- | --------------------------------------- | --------------------------- |
+| Installs skills     | ✅                                      | ✅ (same files)             |
+| Installs MCP server | ✅                                      | ❌                          |
+| Updates             | Through your agent's plugin update flow | Manual re-run               |
+| Files in your repo  | No (agent-managed reference)            | Yes (vendored, committable) |
+| Requires            | Plugin-capable agent version            | Node ≥ 16                   |
+
+Pick **A** unless you specifically don't want the MCP server, want the skills committed into your repo, or
+your agent predates plugin support.
+
+---
+
+## A. As a plugin — skills + MCP in one step
+
+The plugin pulls the skills from this repo and declares the MCP server as `npx -y @shoplflow/mcp`, so you never
+hand-edit an MCP config. Updating the plugin refreshes both the skills and the MCP wiring.
+
+### Claude Code
 
 ```bash
 /plugin marketplace add shopl/shoplflow
 /plugin install shoplflow@shoplflow-marketplace
 ```
 
-**Cursor**
-Open **Customize** → add a team marketplace pointing at the `shopl/shoplflow` GitHub repo (Cursor reads `.cursor-plugin/marketplace.json` at the repo root), then install the **shoplflow** plugin (project or user scope).
+### Cursor
 
-**Codex**
+Open **Customize** → add a team marketplace pointing at the `shopl/shoplflow` GitHub repo (Cursor reads
+`.cursor-plugin/marketplace.json` at the repo root), then install the **shoplflow** plugin (project or user scope).
+
+### Codex
 
 ```bash
 codex plugin marketplace add shopl/shoplflow
 ```
 
-then install the **shoplflow** plugin from the Codex plugin directory.
+Then install the **shoplflow** plugin from the Codex plugin directory.
 
-> Where the manifests live (for maintainers): each host's plugin manifest is under `packages/skills/.{claude,cursor,codex}-plugin/`, and the marketplace catalogs are at the repo root (`.claude-plugin/`, `.cursor-plugin/`, `.agents/plugins/`). All three point at the same `packages/skills/skills/` folder and the same `@shoplflow/mcp` command.
+> **Where the manifests live (maintainers):** each host's plugin manifest is under
+> `packages/skills/.{claude,cursor,codex}-plugin/`, and the marketplace catalogs are at the repo root
+> (`.claude-plugin/`, `.cursor-plugin/`, `.agents/plugins/`). All three point at the same
+> `packages/skills/skills/` folder and the same `@shoplflow/mcp` command.
 
 ---
 
-### B. Skills only via `npx` (no MCP)
+## B. Skills only via `npx` (no MCP)
 
-From the root of the project you want to add the skills to, run:
+From the root of the project you want to add the skills to:
 
 ```bash
-npx @shoplflow/skills            # interactive: asks which agent + scope
+npx @shoplflow/skills            # interactive — asks which agent + scope
 ```
 
-Or non-interactive:
+Non-interactive:
 
 ```bash
 npx @shoplflow/skills --agent claude               # into ./ (current project)
 npx @shoplflow/skills --agent cursor --dir ../app  # into another project
 npx @shoplflow/skills --agent codex --scope global # into your home dir
 npx @shoplflow/skills --agent all                  # claude + codex + cursor
-npx @shoplflow/skills --list                       # preview the skills
+npx @shoplflow/skills --list                       # preview the skills, install nothing
 ```
 
-Flags: `--agent claude|codex|cursor|all` · `--scope project|global` · `--dir <path>` · `--legacy-cursor-rules` · `--yes` · `--list`
+### Flags
+
+| Flag                    | Values                                | Default                | Notes                                                                                                  |
+| ----------------------- | ------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| `--agent`               | `claude` · `codex` · `cursor` · `all` | prompts, else `claude` | `all` writes every format                                                                              |
+| `--scope`               | `project` · `global`                  | `project`              | `global` targets your home dir                                                                         |
+| `--dir <path>`          | any path                              | `cwd`                  | Project scope only; ignored for `global`                                                               |
+| `--legacy-cursor-rules` | –                                     | off                    | Cursor: emit `.cursor/rules/*.mdc` instead of native Agent Skills, for versions predating Agent Skills |
+| `--yes`, `-y`           | –                                     | off                    | Skip the confirmation prompt (use in CI)                                                               |
+| `--list`                | –                                     | –                      | List bundled skills and exit                                                                           |
+| `--help`, `-h`          | –                                     | –                      | Usage                                                                                                  |
+
+Both `--flag value` and `--flag=value` forms work. With no TTY (CI, piped input) the installer never prompts —
+it falls back to `--agent claude --scope project`, so pass flags explicitly in scripts.
 
 > Prefer not to use `npx`? Copy this package folder and run `node install.mjs` with the same flags.
+> The installer has **zero dependencies** and needs Node ≥ 16.
 
-#### Where files land
+### Where files land
 
 | Agent           | Project scope                                                    | Global scope                                            |
 | --------------- | ---------------------------------------------------------------- | ------------------------------------------------------- |
@@ -83,18 +135,163 @@ Flags: `--agent claude|codex|cursor|all` · `--scope project|global` · `--dir <
 | **Cursor**      | `./.cursor/skills/<name>/SKILL.md`                               | `~/.cursor/skills/<name>/SKILL.md`                      |
 | **Codex**       | `./AGENTS.md` (managed block) + `./.codex/skills/shoplflow/*.md` | `~/.codex/AGENTS.md` + `~/.codex/skills/shoplflow/*.md` |
 
-- **Claude**: skills are auto-discovered; the agent loads one when a task matches its description.
-- **Cursor**: installed as native [Agent Skills](https://cursor.com/docs/skills) under `.cursor/skills/` (the same SKILL.md standard as Claude) — Cursor loads them by description on relevant tasks. Pass `--legacy-cursor-rules` to instead emit `.cursor/rules/*.mdc` (_Agent Requested_ rules) for Cursor versions predating Agent Skills.
-- **Codex**: `AGENTS.md` gets a managed block (between `<!-- shoplflow-skills:start -->` / `:end -->`) pointing at the skill files, so Codex reads the right guide on demand. Re-running replaces the block in place — safe and idempotent; your other `AGENTS.md` content is preserved.
+- **Claude** — skills are auto-discovered; the agent loads one when a task matches its description.
+- **Cursor** — installed as native [Agent Skills](https://cursor.com/docs/skills) under `.cursor/skills/`
+  (the same SKILL.md standard as Claude). Pass `--legacy-cursor-rules` to instead emit `.cursor/rules/*.mdc`
+  (_Agent Requested_ rules) for older Cursor versions.
+- **Codex** — `AGENTS.md` gets a managed block between `<!-- shoplflow-skills:start -->` / `:end -->` pointing
+  at the skill files. Re-running replaces the block in place — idempotent, and your other `AGENTS.md` content
+  is preserved.
+
+A `shoplflow-skills.lock.json` is written next to the skills recording the installed version. Agents only scan
+for `SKILL.md` folders, so it's inert — it exists so the `shoplflow-skills-update` skill can tell whether your
+copy is stale. (For Codex, the version lives in the `AGENTS.md` block instead.)
+
+**Commit the installed files** so your whole team gets the same guidance.
+
+---
+
+## Verify the install
+
+```bash
+npx @shoplflow/skills --list     # what should have been written
+ls .claude/skills                # Claude
+ls .cursor/skills                # Cursor
+grep -n "shoplflow-skills:start" AGENTS.md   # Codex
+```
+
+Then check the agent actually picks a skill up. Ask something that matches a description:
+
+> "이 프로젝트에 shoplflow 셋업해줘"
+
+The agent should reference the required `@shoplflow/base/styles` import **and** `ShoplflowProvider` without
+being told — that knowledge comes from `shoplflow-setup`. If it improvises a generic React setup, the skills
+aren't loaded.
+
+---
+
+## Using the skills
+
+You never invoke a skill by name — the agent matches your request against the descriptions. These prompts
+reliably land on the right one:
+
+| Prompt                                        | Skill it pulls                              |
+| --------------------------------------------- | ------------------------------------------- |
+| "shoplflow 설치하고 앱에 연결해줘"            | `shoplflow-setup`                           |
+| "스타일이 하나도 안 먹어" / "Modal이 안 열려" | `shoplflow-setup` (gotchas section)         |
+| "저장/취소 버튼 만들어줘"                     | `shoplflow-components`                      |
+| "이 리스트를 Stack으로 레이아웃 잡아줘"       | `shoplflow-components`                      |
+| "이 카드 스타일을 shoplflow 토큰으로 바꿔줘"  | `shoplflow-theming`                         |
+| "HADA 브랜드일 때만 다른 색 쓰게 해줘"        | `shoplflow-theming` (`getDomain()`)         |
+| "휴지통 아이콘 넣어줘"                        | `shoplflow-icons-utils`                     |
+| "드롭다운 바깥 클릭하면 닫히게 해줘"          | `shoplflow-icons-utils` (`useOutsideClick`) |
+| "shoplflow 스킬 최신이야?"                    | `shoplflow-skills-update`                   |
+
+### What the skills prevent
+
+A sample of the mistakes they exist to stop:
+
+```tsx
+// ❌ token VALUE passed where a KEY is expected
+<Text color={colorTokens.neutral700}>…</Text>
+// ✅ props take the key string
+<Text color="neutral700">…</Text>
+
+// ❌ typography token inlined as if it were CSS properties
+const Bad = styled.p`${typographyTokens.body1_400}`;   // it's a class SELECTOR, ".body1_400"
+// ✅
+<Text typography="body1_400">…</Text>
+
+// ❌ overlays outside the provider — they silently never appear
+<Modal … />
+// ✅ wrap the tree once at the entry
+<ShoplflowProvider domain="SHOPL"><App /></ShoplflowProvider>
+```
+
+Adding the [MCP server](../mcp) on top gives the agent exact values too — the real `styleVar` list, the real
+icon names, the real token values. Path A installs both.
+
+---
 
 ## Updating / uninstalling
 
-- **Plugin (path A)**: update through your agent's marketplace/plugin update flow (e.g. Claude Code `/plugin marketplace update`), which re-pulls the latest skills and MCP wiring from this repo. Uninstall by removing the plugin in your agent.
-- **npx (path B)**: re-run `npx @shoplflow/skills@latest --agent <…>` (pin `@latest` to skip the npx cache). Files are overwritten in place, the installer records the version in `shoplflow-skills.lock.json`, and for Cursor it auto-removes superseded `.cursor/rules/*.mdc` from pre-`0.2.0` installs. The bundled `shoplflow-skills-update` skill lets your agent compare that lock against `npm view @shoplflow/skills version` and update when behind. npx skills are vendored, so they never auto-update — re-run to refresh.
-- **Uninstall (npx)**: delete the `<name>` skill folders under `.claude/skills/` / `.cursor/skills/` (or the `.cursor/rules/*.mdc` files if you used `--legacy-cursor-rules`), and for Codex remove the managed block from `AGENTS.md` plus `.codex/skills/shoplflow/`.
+### Plugin (path A)
+
+Update through your agent's marketplace/plugin update flow (e.g. Claude Code `/plugin marketplace update`),
+which re-pulls the latest skills and MCP wiring from this repo. Uninstall by removing the plugin in your agent.
+
+### npx (path B)
+
+Vendored files never auto-update — re-run to refresh:
+
+```bash
+npx @shoplflow/skills@latest --agent claude --yes
+```
+
+Pin `@latest` to skip the npx cache. Files are overwritten in place, the version is re-stamped in
+`shoplflow-skills.lock.json`, and for Cursor the installer auto-removes superseded `.cursor/rules/*.mdc` from
+pre-`0.2.0` installs (only its own slugs — your other rules are untouched).
+
+The bundled `shoplflow-skills-update` skill automates the check: it reads the lock file, runs
+`npm view @shoplflow/skills version`, and tells you whether to re-run. Just ask your agent if the skills are current.
+
+### Uninstall (npx)
+
+- Delete the skill folders under `.claude/skills/` / `.cursor/skills/` (or the `.cursor/rules/*.mdc` files if you
+  used `--legacy-cursor-rules`), plus `shoplflow-skills.lock.json`.
+- For Codex, remove the managed block from `AGENTS.md` and delete `.codex/skills/shoplflow/`.
+
+---
+
+## For maintainers
+
+### Adding a skill
+
+1. Create `skills/<name>/SKILL.md`. **The folder name must equal the frontmatter `name`** — Cursor requires it.
+2. Write `description` as a trigger spec: `[what it covers]. Use when [concrete situations]`. Include the
+   _symptoms_ a user would actually type, not just the causes.
+3. Reference **published npm APIs only** (`@shoplflow/base`, `@shoplflow/utils`, `@shoplflow/shopl-assets`,
+   `@shoplflow/hada-assets`) — never monorepo paths. Skills get copied into consumer projects.
+4. Cross-reference other skills **by name** (`See the **shoplflow-setup** skill`), not by path.
+5. Keep the frontmatter flat `key: value` — the installer's parser is a one-line regex, not a YAML engine.
+6. Add a row to the [What's inside](#whats-inside) table.
+7. Verify: `node install.mjs --list`, then `node install.mjs --agent all --dir /tmp/probe --yes` and inspect
+   all three output formats.
+8. Add a changeset. On release, `install.mjs` stamps the new version automatically.
+
+No plugin manifest edits needed — they point at the whole `./skills/` directory.
+
+### Keeping skills accurate
+
+Skills are hand-written, so unlike the MCP they _can_ drift. Re-check them when `base` changes:
+
+| `base` change                                | Re-check                                       |
+| -------------------------------------------- | ---------------------------------------------- |
+| `styleVar`/`sizeVar` values added or removed | `shoplflow-components`                         |
+| typography tokens added or removed           | `shoplflow-components`, `shoplflow-theming`    |
+| peer deps or CSS export paths change         | `shoplflow-setup`                              |
+| new component exported                       | `shoplflow-components` (catalog at the bottom) |
+| new `@shoplflow/utils` hook                  | `shoplflow-icons-utils`                        |
+
+Bump the "Verified against" line below when you do.
+
+### Changing the MCP server command
+
+`npx -y @shoplflow/mcp` is declared in four places — update all of them:
+`.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, `.mcp.json` (Codex reads this one), and this README.
+
+---
 
 ## Notes
 
-- Skills are **self-contained** — they reference only the published npm package API (`@shoplflow/base`, `@shoplflow/utils`, `@shoplflow/shopl-assets`, `@shoplflow/hada-assets`), no monorepo internals — so they work in any consumer project.
+- Skills are **self-contained** — they reference only the published npm package API, so they work in any
+  consumer project.
 - The `npx` installer has **no dependencies** and needs Node ≥ 16.
-- Verified against: `@shoplflow/base@0.48.0`, `@shoplflow/utils@0.8.0`, `@shoplflow/shopl-assets@0.12.44`, `@shoplflow/hada-assets@0.1.10`.
+- Verified against: `@shoplflow/base@0.48.0`, `@shoplflow/utils@0.8.0`, `@shoplflow/shopl-assets@0.12.44`,
+  `@shoplflow/hada-assets@0.1.10`.
+
+## Related
+
+- [아키텍쳐.md](./아키텍쳐.md) — internal architecture, install pipeline, extension guide
+- [`@shoplflow/mcp`](../mcp) — the MCP server bundled by the plugin
+- [CLAUDE.md](../../CLAUDE.md) — monorepo guide

--- a/packages/skills/아키텍쳐.md
+++ b/packages/skills/아키텍쳐.md
@@ -1,0 +1,388 @@
+# @shoplflow/skills 아키텍쳐
+
+> shoplflow 디자인 시스템을 **소비하는 개발자**의 AI 에이전트에게 사용법을 가르치는 스킬 패키지 + 플러그인의 내부 구조 문서.
+> 사용법은 [README.md](./README.md)를 참고하세요. 이 문서는 **왜 이렇게 만들었는지 / 어디를 고쳐야 하는지**를 다룹니다.
+
+---
+
+## 1. 이 패키지가 푸는 문제
+
+`@shoplflow/mcp`가 **"정확한 사실"**(토큰 값, prop 목록, 아이콘 이름)을 조회로 제공한다면, 스킬은 **"어떻게 쓰는가"**(관용구, 함정, 순서)를 가르칩니다.
+
+에이전트가 툴을 호출하려면 먼저 **"이 프로젝트는 shoplflow를 쓰고, Provider 없이는 아무것도 안 뜬다"**는 것을 알아야 합니다. 그게 스킬의 역할입니다.
+
+### 스킬 ↔ MCP 역할 분담
+
+|         | 스킬 (SKILL.md)                                              | MCP (`@shoplflow/mcp`)                                            |
+| ------- | ------------------------------------------------------------ | ----------------------------------------------------------------- |
+| 성격    | **정적 지식** — 프롬프트에 주입되는 텍스트                   | **동적 조회** — 툴 호출로 가져오는 데이터                         |
+| 담는 것 | 관용구, 셋업 순서, KEY vs VALUE 구분, 함정, 언제 무엇을 쓰나 | 114개 토큰 값, 65개 컴포넌트 API, 473개 아이콘, 149개 스토리 예제 |
+| 갱신    | 사람이 작성 → npm 배포 → 벤더링/플러그인 갱신                | 라이브러리 빌드 시 자동 추출                                      |
+| 로딩    | 에이전트가 `description` 매칭으로 필요할 때 로드             | 에이전트가 필요할 때 툴 호출                                      |
+| 없으면  | 셋업 누락, 잘못된 패턴, "왜 안 뜨지"                         | 토큰/prop 환각                                                    |
+
+**둘은 대체재가 아니라 보완재입니다.** 그래서 플러그인 경로(A)가 둘을 한 번에 설치합니다.
+
+### base 릴리즈 동기화 방식이 정반대입니다
+
+|                | MCP                                      | 스킬                               |
+| -------------- | ---------------------------------------- | ---------------------------------- |
+| base 변경 반영 | **자동** — 빌드 시 소스에서 재추출       | **수동** — 사람이 SKILL.md 수정    |
+| 버전 범프      | **자동** — changesets가 dependent로 범프 | **없음** — base 의존성이 아예 없음 |
+| 검증           | CI가 메타데이터 신선도 + 배선 검사       | 없음 (아래 10절 체크리스트에 의존) |
+
+스킬 `package.json`에는 `@shoplflow/*` 의존성이 **하나도 없습니다.** 그래서 changesets가 dependent로 인식하지 못하고, base를 아무리 배포해도 스킬 버전은 그대로입니다. CHANGELOG를 봐도 3개 릴리즈 전부 스킬 자체 변경이고 base발 범프는 한 건도 없습니다.
+
+이건 버그가 아니라 **의도된 설계**입니다 — SKILL.md는 추출물이 아니라 사람이 쓴 판단이라 자동화할 대상이 아닙니다. 다만 그래서 **드리프트 책임이 전적으로 사람에게 있습니다.**
+
+---
+
+## 2. 핵심 설계 원칙
+
+| 원칙                     | 구현                                                              | 이유                                                                         |
+| ------------------------ | ----------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| **단일 소스, 다중 타깃** | `skills/<name>/SKILL.md` 하나를 Claude/Cursor/Codex 포맷으로 변환 | 에이전트마다 문서를 따로 쓰면 즉시 어긋남                                    |
+| **개방 표준 채택**       | SKILL.md(프론트매터 + 마크다운) 표준 사용                         | Claude Code와 Cursor가 **변환 없이** 그대로 읽음. 어댑터가 필요한 건 Codex뿐 |
+| **자기 완결성**          | 스킬은 **공개 npm API만** 참조 (모노레포 내부 경로 없음)          | 소비자 프로젝트에 그대로 복사돼도 유효해야 함                                |
+| **의존성 0 인스톨러**    | `install.mjs`가 Node 내장 모듈만 사용                             | `npx`로 즉시 실행. 설치 지연·보안 표면 최소화                                |
+| **멱등성**               | 재실행 시 파일 덮어쓰기, Codex는 마커 블록 in-place 교체          | 반복 실행이 안전해야 업데이트 플로우가 성립                                  |
+| **버전 스탬프**          | `shoplflow-skills.lock.json` 기록                                 | 벤더링은 자동 갱신이 안 되므로, "낡았는지" 판단할 근거 필요                  |
+| **자기 갱신 스킬**       | `shoplflow-skills-update` 스킬이 lock ↔ npm 최신 비교             | 사람이 기억하지 않아도 에이전트가 스스로 체크                                |
+
+---
+
+## 3. 전체 구조
+
+```mermaid
+flowchart TB
+  subgraph SRC["소스 (단일 출처)"]
+    S["packages/skills/skills/&lt;name&gt;/SKILL.md × 5"]
+  end
+
+  subgraph A["경로 A — 플러그인 (스킬 + MCP)"]
+    MP["레포 루트 마켓플레이스 카탈로그<br/>.claude-plugin/ · .cursor-plugin/ · .agents/plugins/"]
+    PM["packages/skills/.{claude,cursor,codex}-plugin/plugin.json"]
+    MCPJ[".mcp.json → npx -y @shoplflow/mcp"]
+  end
+
+  subgraph B["경로 B — npx 벤더링 (스킬만)"]
+    IN["install.mjs<br/>(의존성 0)"]
+  end
+
+  subgraph T["설치 결과 (소비자 프로젝트)"]
+    TC[".claude/skills/&lt;name&gt;/SKILL.md"]
+    TU[".cursor/skills/&lt;name&gt;/SKILL.md"]
+    TX["AGENTS.md 관리 블록<br/>+ .codex/skills/shoplflow/&lt;name&gt;.md"]
+    LK["shoplflow-skills.lock.json"]
+  end
+
+  S --> PM
+  S --> IN
+  MP --> PM
+  PM --> MCPJ
+  PM -->|에이전트 플러그인 설치| TC
+  PM --> TU
+  PM --> TX
+  IN --> TC
+  IN --> TU
+  IN --> TX
+  IN --> LK
+```
+
+### 디렉터리 맵
+
+```
+packages/skills/
+├── skills/                       ★ 단일 출처 — 여기만 고치면 모든 경로에 반영
+│   ├── shoplflow-setup/SKILL.md
+│   ├── shoplflow-components/SKILL.md
+│   ├── shoplflow-theming/SKILL.md
+│   ├── shoplflow-icons-utils/SKILL.md
+│   └── shoplflow-skills-update/SKILL.md
+├── install.mjs                   경로 B 인스톨러 (bin: shoplflow-skills)
+├── .mcp.json                     Codex 플러그인이 참조하는 MCP 서버 선언
+├── .claude-plugin/plugin.json    Claude Code 플러그인 매니페스트 (mcpServers 인라인)
+├── .cursor-plugin/plugin.json    Cursor 플러그인 매니페스트 (mcpServers 인라인)
+└── .codex-plugin/plugin.json     Codex 플러그인 매니페스트 (mcpServers → ./.mcp.json)
+
+레포 루트 (마켓플레이스 카탈로그 — 에이전트가 여기를 먼저 읽음)
+├── .claude-plugin/marketplace.json    source: ./packages/skills
+├── .cursor-plugin/marketplace.json    source: packages/skills
+└── .agents/plugins/marketplace.json   source: git-subdir → ./packages/skills @ main
+```
+
+---
+
+## 4. SKILL.md — 스킬의 해부
+
+```markdown
+---
+name: shoplflow-setup                 ← 폴더명과 반드시 일치 (Cursor 요구사항)
+description: Install and configure …  ← 에이전트가 "언제 로드할지" 판단하는 유일한 근거
+---
+
+# @shoplflow setup
+
+…본문…
+```
+
+### `description`이 아키텍쳐적으로 중요한 이유
+
+에이전트는 스킬 본문을 **항상 읽지 않습니다.** 컨텍스트를 아끼기 위해 `name` + `description`만 상시 로드하고, 작업이 매칭될 때 본문을 가져옵니다(점진적 공개, progressive disclosure).
+
+따라서 `description`은 요약문이 아니라 **트리거 명세**입니다. 실제로 이 패키지의 스킬들은 전부 두 문장 구조를 따릅니다.
+
+```
+[무엇을 다루는가]. Use when [구체적 상황 나열].
+```
+
+예시(`shoplflow-setup`): _"Use when setting up @shoplflow, installing @shoplflow/base, wrapping an app with ShoplflowProvider, **fixing missing design tokens/typography/styles, broken Modal/Tooltip/Popper portals**, or choosing a brand domain."_
+
+→ 증상("모달이 안 떠요")으로도 매칭되도록 의도적으로 나열합니다. 사용자는 원인이 아니라 증상을 말하기 때문입니다.
+
+### 5개 스킬의 경계
+
+| 스킬                      | 담당                                                              | 경계 규칙                                      |
+| ------------------------- | ----------------------------------------------------------------- | ---------------------------------------------- |
+| `shoplflow-setup`         | 설치, peer deps, 필수 global CSS, `ShoplflowProvider`, SHOPL/HADA | **전제조건 스킬** — 나머지 3개가 여기를 역참조 |
+| `shoplflow-components`    | 컴포넌트 사용, `styleVar`/`sizeVar`, 다형성 `as`, 오버레이        | prop **키**를 쓰는 법. 값의 정의는 theming으로 |
+| `shoplflow-theming`       | 토큰 객체, **KEY vs VALUE** 구분, `getDomain()` 브랜드 분기       | 커스텀 emotion 코드를 쓸 때                    |
+| `shoplflow-icons-utils`   | 에셋 패키지 아이콘/일러스트 + `@shoplflow/utils` 훅               | 두 개의 보조 패키지                            |
+| `shoplflow-skills-update` | 설치된 스킬 버전 점검·갱신                                        | **메타 스킬** — 다른 스킬의 신선도를 관리      |
+
+> 스킬 간 참조는 이름으로 합니다(_"See the **shoplflow-setup** skill"_). 경로가 아니라 이름이므로 Claude/Cursor/Codex 어디에 설치돼도 유효합니다.
+
+---
+
+## 5. 경로 A — 플러그인 (스킬 + MCP)
+
+### 2단 구조: 마켓플레이스 카탈로그 → 플러그인 매니페스트
+
+에이전트는 **레포 루트**의 카탈로그를 먼저 읽고, 거기서 지목한 디렉터리의 매니페스트를 읽습니다.
+
+```
+사용자: /plugin marketplace add shopl/shoplflow
+  └ 에이전트가 레포 루트의 .claude-plugin/marketplace.json 읽음
+      └ plugins[0].source = "./packages/skills"
+          └ packages/skills/.claude-plugin/plugin.json 읽음
+              ├ "skills": "./skills/"          → 5개 스킬 등록
+              └ "mcpServers": { shoplflow: npx -y @shoplflow/mcp }  → MCP 연결
+```
+
+카탈로그가 레포 루트에 있어야 하는 이유는 **에이전트가 `owner/repo` 문자열만 받기 때문**입니다. 서브디렉터리를 알 방법이 없으므로 루트에서 시작합니다.
+
+### 호스트 3종 차이
+
+|                 | 카탈로그 위치                      | 매니페스트                   | MCP 선언 방식                 | source 표기                          |
+| --------------- | ---------------------------------- | ---------------------------- | ----------------------------- | ------------------------------------ |
+| **Claude Code** | `.claude-plugin/marketplace.json`  | `.claude-plugin/plugin.json` | 인라인 `mcpServers` 객체      | `./packages/skills`                  |
+| **Cursor**      | `.cursor-plugin/marketplace.json`  | `.cursor-plugin/plugin.json` | 인라인 `mcpServers` (+ `env`) | `packages/skills`                    |
+| **Codex**       | `.agents/plugins/marketplace.json` | `.codex-plugin/plugin.json`  | **파일 참조** `"./.mcp.json"` | `git-subdir` 객체 (url + path + ref) |
+
+> Codex만 `mcpServers`를 파일 경로로 받습니다. 그래서 `packages/skills/.mcp.json`이 별도로 존재합니다 — Claude/Cursor는 이 파일을 쓰지 않습니다.
+
+**세 매니페스트 모두 같은 `skills/` 폴더와 같은 `npx -y @shoplflow/mcp` 명령을 가리킵니다.** 포맷만 다르고 내용은 동일합니다.
+
+### 루트 `.mcp.json`과 혼동하지 말 것
+
+레포 루트에도 `.mcp.json`이 있지만 이건 **모노레포 개발자용**입니다.
+
+```jsonc
+// 레포 루트 .mcp.json — 로컬 빌드를 직접 가리킴 (개발용)
+{ "command": "node", "args": ["packages/mcp/dist/index.js"] }
+
+// packages/skills/.mcp.json — 배포된 npm 패키지 (소비자용)
+{ "command": "npx", "args": ["-y", "@shoplflow/mcp"] }
+```
+
+---
+
+## 6. 경로 B — `install.mjs` 벤더링
+
+### 파이프라인
+
+```
+parseArgs(argv)
+  └ loadSkills()            skills/*/SKILL.md 읽기 → 프론트매터 파싱 → { slug, description, body, raw }
+      └ [interactive()]     agent/scope 누락 + TTY일 때만 프롬프트
+          └ INSTALLERS[target](skills, scope, dir, written, legacyRules)
+              ├ installClaude   raw 그대로 복사
+              ├ installCursor   raw 그대로 복사 (+ 레거시 마이그레이션)
+              └ installCodex    body 변환 + AGENTS.md 관리 블록 주입
+                  └ stampVersion()  shoplflow-skills.lock.json 기록
+```
+
+### 프론트매터 파서 — 왜 직접 짰나
+
+의존성 0 원칙 때문에 YAML 파서를 쓰지 않습니다. `^([A-Za-z0-9_-]+):\s*(.*)$` 한 줄 정규식으로 충분합니다 — 스킬 프론트매터가 **평면 key-value뿐**이라는 것이 전제입니다.
+
+> **제약**: 중첩 구조·여러 줄 값·YAML 앵커를 쓰면 조용히 무시됩니다. 스킬을 추가할 때 프론트매터를 평면으로 유지하세요.
+
+### 에이전트별 어댑터
+
+| 에이전트                             | 출력                                                          | 변환                                                                                 |
+| ------------------------------------ | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Claude Code**                      | `<base>/.claude/skills/<slug>/SKILL.md`                       | **없음** — `raw` 그대로                                                              |
+| **Cursor** (기본)                    | `<base>/.cursor/skills/<slug>/SKILL.md`                       | **없음** — `raw` 그대로 (같은 표준)                                                  |
+| **Cursor** (`--legacy-cursor-rules`) | `<base>/.cursor/rules/<slug>.mdc`                             | 프론트매터를 MDC로 재작성 (`description` + `globs:` + `alwaysApply: false`)          |
+| **Codex**                            | `<base>/.codex/skills/shoplflow/<slug>.md` + `AGENTS.md` 블록 | `# <slug>` 헤딩 + `> description` 인용 + `body`. AGENTS.md에 상대경로 링크 목록 주입 |
+
+`scope=global`이면 `<base>`가 `os.homedir()`, `project`면 `--dir` 또는 `cwd`입니다. Codex만 예외적으로 global일 때 `AGENTS.md`가 `~/.codex/AGENTS.md`로 갑니다(프로젝트 스코프는 `./AGENTS.md`).
+
+### Codex 관리 블록 — 멱등성의 핵심
+
+```markdown
+<!-- shoplflow-skills:start -->
+
+## @shoplflow design system
+
+> Installed @shoplflow/skills version: 0.2.1
+
+When the task involves `@shoplflow/*` packages …:
+
+- [shoplflow-setup](.codex/skills/shoplflow/shoplflow-setup.md) — …
+
+<!-- shoplflow-skills:end -->
+```
+
+마커 쌍이 존재하면 **정규식으로 그 구간만 치환**하고, 없으면 파일 끝에 append합니다. 사용자가 `AGENTS.md`에 쓴 다른 내용은 절대 건드리지 않습니다.
+
+Codex는 lock 파일 대신 **이 블록 안의 버전 라인**이 버전 기록입니다(`AGENTS.md`가 유일한 진입점이므로).
+
+### Cursor 레거시 마이그레이션
+
+0.2.0 이전 인스톨러는 Cursor를 `.cursor/rules/<slug>.mdc`로 설치했습니다. 현재 인스톨러는 네이티브 Agent Skills로 설치한 뒤, **자기 slug의 `.mdc`만 골라서 삭제**합니다.
+
+```js
+for (const s of skills) {
+  const legacy = `.cursor/rules/${s.slug}.mdc`;
+  if (exists) rm(legacy);
+}
+```
+
+디렉터리를 통째로 지우지 않는 이유: 사용자가 직접 만든 룰이 같은 폴더에 있기 때문입니다.
+
+### 버전 스탬프
+
+```json
+{ "name": "@shoplflow/skills", "version": "0.2.1", "installedAt": "2026-…" }
+```
+
+스킬 루트(`.claude/skills/`, `.cursor/skills/`)에 씁니다. 에이전트는 `SKILL.md`를 가진 폴더만 스캔하므로 이 JSON은 무시됩니다 — 안전한 기생 위치입니다.
+
+---
+
+## 7. 업데이트 모델
+
+두 경로의 갱신 방식이 **근본적으로 다릅니다.**
+
+|             | 경로 A (플러그인)                   | 경로 B (npx)                     |
+| ----------- | ----------------------------------- | -------------------------------- |
+| 설치 형태   | 에이전트가 레포에서 pull (참조)     | 프로젝트로 파일 복사 (벤더링)    |
+| 갱신        | 에이전트의 플러그인 업데이트 플로우 | **수동 재실행** — 자동 갱신 없음 |
+| MCP 포함    | ✅                                  | ❌                               |
+| 신선도 추적 | 에이전트가 관리                     | `shoplflow-skills.lock.json`     |
+
+경로 B가 자동 갱신되지 않는다는 것이 `shoplflow-skills-update` 스킬이 존재하는 이유입니다.
+
+```
+사용자: "shoplflow 스킬 최신이야?"
+  └ shoplflow-skills-update 스킬 로드 (description 매칭)
+      ├ lock 파일에서 설치 버전 읽기 (없으면 ≤0.1.0 → 낡음 판정)
+      ├ npm view @shoplflow/skills version
+      └ 낮으면 npx @shoplflow/skills@latest --agent <…> 재실행 안내
+```
+
+> `@latest`를 붙이는 이유: npx가 이전에 받은 버전을 캐시하기 때문입니다.
+
+---
+
+## 8. 확장 가이드
+
+### 새 스킬 추가
+
+1. `skills/<name>/SKILL.md` 생성. **폴더명 = 프론트매터 `name`** (Cursor 요구사항).
+2. `description`을 트리거 명세로 작성 — `[무엇]. Use when [상황 나열]`. 사용자가 말할 법한 **증상**을 포함.
+3. 본문은 **공개 npm API만** 참조. `packages/base/src/...` 같은 모노레포 경로 금지.
+4. 다른 스킬은 **이름으로** 참조 (`See the **shoplflow-setup** skill`).
+5. 프론트매터는 평면 key-value 유지 (인스톨러 파서 제약).
+6. `README.md`의 스킬 표에 행 추가.
+7. `npx . --list`로 파싱 확인 → `node install.mjs --agent all --dir /tmp/probe --yes`로 3개 타깃 출력 확인.
+8. changeset 작성 → 배포 시 `install.mjs`의 `VERSION`이 자동으로 새 버전을 스탬프.
+
+> 플러그인 매니페스트는 **수정할 필요가 없습니다.** `"skills": "./skills/"` 디렉터리 전체를 가리키므로 자동 반영됩니다.
+
+### 새 에이전트 호스트 지원
+
+1. `install.mjs`에 `install<Agent>()` 추가 → `INSTALLERS` 맵과 `AGENTS` 배열에 등록 → `--help`/대화형 메뉴 갱신.
+2. 플러그인도 지원하면 `packages/skills/.<agent>-plugin/plugin.json` + 레포 루트 카탈로그 추가.
+3. 해당 호스트가 `mcpServers`를 인라인으로 받는지 파일 참조로 받는지 확인 (Codex가 후자).
+
+### MCP 서버 명령 변경
+
+`npx -y @shoplflow/mcp`가 **4곳**에 중복 선언돼 있습니다. 바꿀 때 전부 갱신하세요.
+
+```
+packages/skills/.claude-plugin/plugin.json   (인라인)
+packages/skills/.cursor-plugin/plugin.json   (인라인)
+packages/skills/.mcp.json                    (Codex가 참조)
+README.md                                    (수동 설정 안내)
+```
+
+---
+
+## 9. 설계 결정 & 트레이드오프
+
+| 결정                       | 대안                       | 선택 이유                                                                           |
+| -------------------------- | -------------------------- | ----------------------------------------------------------------------------------- |
+| 두 경로 병행 유지          | 플러그인만                 | 플러그인 미지원 에이전트 버전이 아직 있음. npx는 MCP 없이 스킬만 원하는 팀에도 유효 |
+| 벤더링(복사)               | 심볼릭 링크 / 런타임 fetch | 소비자 레포에 커밋되어 팀원 전체가 동일 버전 공유. 오프라인 동작                    |
+| 의존성 0 인스톨러          | commander + yaml           | `npx` 콜드 스타트 최소화 + 공급망 표면 제거. 대가: 직접 짠 파서의 제약              |
+| SKILL.md 표준 채택         | 자체 포맷                  | Claude·Cursor가 무변환으로 읽음. 신규 호스트 대응 비용 최소                         |
+| Codex를 AGENTS.md 블록으로 | 별도 설정 파일             | Codex의 유일한 안정적 진입점이 `AGENTS.md`. 마커로 멱등성 확보                      |
+| lock 파일을 스킬 폴더 안에 | 프로젝트 루트              | 스킬과 생명주기가 같음. 에이전트가 무시하는 위치                                    |
+| 갱신을 스킬로 구현         | CLI `--check` 플래그       | 사용자가 기억할 필요 없이 에이전트가 대화 중 판단                                   |
+
+---
+
+## 10. 유지보수 체크리스트
+
+### 라이브러리 변경 시 스킬 검증이 필요한 지점
+
+스킬은 **자동 생성이 아니므로 드리프트가 가능합니다.** (MCP와의 근본적 차이 — 이건 의도된 트레이드오프입니다: 스킬은 "판단"을 담고, 판단은 추출할 수 없습니다.)
+
+| `base` 변경                                  | 확인할 스킬                                                       |
+| -------------------------------------------- | ----------------------------------------------------------------- |
+| variant 값 추가/삭제 (`styleVar`, `sizeVar`) | `shoplflow-components` (하드코딩된 값 목록)                       |
+| 타이포그래피 토큰 추가/삭제                  | `shoplflow-components` (typography 키 목록) · `shoplflow-theming` |
+| peer deps / CSS export 경로 변경             | `shoplflow-setup`                                                 |
+| 신규 컴포넌트 export                         | `shoplflow-components` 하단 카탈로그                              |
+| `@shoplflow/utils` 훅 추가                   | `shoplflow-icons-utils`                                           |
+
+> README 하단의 _"Verified against: @shoplflow/base@0.48.0 …"_ 줄이 마지막 검증 시점입니다. 스킬을 갱신할 때 이 버전도 함께 올리세요.
+
+**드리프트를 줄이는 방향**: 스킬에는 자주 바뀌는 구체값(variant 목록, 타이포그래피 키)을 최소한만 두고, 정확한 값은 MCP 조회에 위임할수록 유지보수 부담이 줄어듭니다. 현재 `shoplflow-components`가 이 값들을 통째로 나열하고 있어 가장 썩기 쉽습니다.
+
+### 깨지기 쉬운 지점
+
+| 위치                            | 가정                                            | 깨지면                                               |
+| ------------------------------- | ----------------------------------------------- | ---------------------------------------------------- |
+| `parseSkill()`                  | 프론트매터가 평면 key-value                     | 해당 필드 조용히 누락                                |
+| 폴더명 = `name`                 | Cursor가 일치를 요구                            | Cursor에서 스킬 미인식                               |
+| Codex 마커 정규식               | `<!-- shoplflow-skills:start/end -->` 쌍이 온전 | 블록이 중복 append                                   |
+| 루트 마켓플레이스 `source` 경로 | `packages/skills` 위치 고정                     | 플러그인 설치 실패                                   |
+| 매니페스트 `version` 필드       | `package.json` 버전과 **별개로 수동 관리**      | 현재 0.1.0으로 고정 — 플러그인 갱신 감지에 영향 가능 |
+
+### 알려진 갭
+
+- `package.json`에 `scripts`가 없습니다 — 빌드·테스트·린트가 없는 순수 파일 배포 패키지입니다. 검증은 `node install.mjs --list` / 임시 디렉터리 설치가 전부입니다.
+- 플러그인 매니페스트 3종의 `version`(0.1.0)이 `package.json`(0.2.1)과 어긋나 있습니다. 릴리즈 시 함께 올릴지 팀 정책 확인이 필요합니다.
+- 스킬 본문의 하드코딩된 값은 자동 검증되지 않습니다. MCP 쪽에는 `check-release-wiring.cjs` + 메타데이터 신선도 CI가 있지만, 스킬 쪽에 대응하는 자동 검증은 없고 위 체크리스트에 의존합니다.
+
+---
+
+## 11. 관련 문서
+
+- [README.md](./README.md) — 설치·사용법·플래그 레퍼런스
+- [../mcp/아키텍쳐.md](../mcp/아키텍쳐.md) — 함께 배포되는 MCP 서버 (자동 동기화 구조 포함)
+- [../../CLAUDE.md](../../CLAUDE.md) — 모노레포 전체 가이드

--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,7 @@
   "globalDependencies": [
     "**/.env.*local"
   ],
+  "//": "tasks.build:package — `turbo run build` also runs build:package in packages that define ONLY it and no `build` script (turbo expands the task graph across every package). @shoplflow/mcp depends on this: it has no `build` script, yet CI's `pnpm build` must run its build:package (regenerate design-system metadata + bundle) before `changeset publish`. `^build:package` is also what orders mcp after base/assets — mcp declares those as workspace devDependencies purely for that ordering and for changesets' dependent version bump. Verify with `pnpm --filter @shoplflow/mcp check:wiring`; rationale in packages/mcp/아키텍쳐.md section 6.",
   "tasks": {
     "build:illustrations": {
       "cache": false


### PR DESCRIPTION
@shoplflow/mcp·@shoplflow/skills의 내부 구조 문서를 추가하고 README에 사용법을 상세히 보강했습니다. 문서화 과정에서 "base 릴리즈 → mcp 자동 재배포" 연동이
여러 설정에 암묵적으로 흩어져 있고 하나만 빠져도 조용히 멈춘다는 점을 확인해,
해당 불변식을 실행 가능한 검사와 주석으로 고정했습니다.

문서
- packages/{mcp,skills}/아키텍쳐.md 신규: 레이어 구조, 추출 파이프라인, 설계 결정과 트레이드오프, 깨지기 쉬운 지점, 확장 가이드
- 두 패키지 README 보강: 클라이언트별 연결 설정, MCP 툴 8종 전체 레퍼런스 (파라미터 + 실제 응답), 인스톨러 플래그 레퍼런스, 트러블슈팅, 유지보수 가이드

메타데이터 재생성
- 커밋된 src/data/*.generated.json이 base 소스보다 밀려 있어 재생성 (tokens 113→114, icons 451→473, components 63→65, examples 142→149)
- 배포물은 build:package가 매번 재생성하므로 npm 배포본은 이전에도 최신이었고, PR diff로 변경 영향을 리뷰하기 위한 커밋본만 어긋난 상태였습니다

CI 검증
- scripts/check-release-wiring.cjs 신규 (pnpm --filter @shoplflow/mcp check:wiring): 워크스페이스 devDeps · build:package의 generate:metadata 체인 · turbo의 mcp#build:package 스케줄링 세 불변식 검증
- build-test.yml(PR CI)에 배선 검증 + 커밋된 메타데이터 신선도 검사 추가. 신선도 검사는 turbo 캐시 히트 시 위양성이 나므로 generate:metadata를 명시 재실행
- package.json·turbo.json("//" 노트)·generate-metadata.cjs에 결합 관계 주석 명시

## 🔨작업 내용

<!-- 작업한 내용을 적어주세요. -->


<!-- 관련있는 이슈 번호(#000)를 PR 제목에 적어주세요. -->

<!-- ex) [SF-1234] 무슨 기능 업데이트 -->

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->

## 머지 전 확인해주세요.

> shoplflow는 [트렁크 기반 전략](https://www.notion.so/shoplworks/Gitflow-19b201245a6d4d129731ec2136c62a8e?pvs=4)을 사용하고 있습니다.
>
> 머지 전에 아래 항목들을 확인해주세요.

- [ ] 추가되는 기능에 대한 테스트 코드가 작성되었나요?
- [ ] 해당 업데이트로 인해 기존에 작성된 테스트 코드가 실패하지 않나요?
- [ ] 머지 전에 빌드가 성공했나요?
- [ ] 린트가 적용되어 있나요?
